### PR TITLE
Page layout metrics

### DIFF
--- a/src/Exception/LayoutMetricsFailed.php
+++ b/src/Exception/LayoutMetricsFailed.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @license see LICENSE
+ */
+
+namespace HeadlessChromium\Exception;
+
+class LayoutMetricsFailed extends \Exception
+{
+
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -16,6 +16,7 @@ use HeadlessChromium\Exception\TargetDestroyed;
 use HeadlessChromium\Input\Mouse;
 use HeadlessChromium\PageUtils\CookiesGetter;
 use HeadlessChromium\PageUtils\PageEvaluation;
+use HeadlessChromium\PageUtils\PageLayoutMetrics;
 use HeadlessChromium\PageUtils\PageNavigation;
 use HeadlessChromium\PageUtils\PageScreenshot;
 use HeadlessChromium\PageUtils\ResponseWaiter;
@@ -65,6 +66,30 @@ class Page
         $this->getSession()->sendMessageSync(
             new Message('Page.addScriptToEvaluateOnNewDocument', ['source' => $script])
         );
+    }
+
+    /**
+     * Retrieves layout metrics of the page
+     *
+     * Example:
+     *
+     * ```php
+     * $metrics = $page->getLayoutMetrics();
+     * $contentSize = $metrics->getContentSize();
+     * ```
+     *
+     * @return PageLayoutMetrics
+     * @throws CommunicationException
+     */
+    public function getLayoutMetrics()
+    {
+        $this->assertNotClosed();
+
+        $reader = $this->getSession()->sendMessage(
+            new Message('Page.getLayoutMetrics')
+        );
+
+        return new PageLayoutMetrics($reader);
     }
 
     /**

--- a/src/PageUtils/PageLayoutMetrics.php
+++ b/src/PageUtils/PageLayoutMetrics.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace HeadlessChromium\PageUtils;
+
+use HeadlessChromium\Communication\Response;
+use HeadlessChromium\Communication\ResponseReader;
+use HeadlessChromium\Exception\LayoutMetricsFailed;
+
+/**
+ * Used to read layout metrics of the page
+ * @internal
+ */
+class PageLayoutMetrics
+{
+
+    /**
+     * @var ResponseReader
+     */
+    protected $responseReader;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    public function __construct(ResponseReader $responseReader)
+    {
+        $this->responseReader = $responseReader;
+    }
+
+    public function waitForResponse()
+    {
+        $this->response = $this->responseReader->waitForResponse();
+
+        if (!$this->response->isSuccessful()) {
+            throw new LayoutMetricsFailed('Could not retrieve layout metrics of the page.');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns raw page metrics data
+     * @return array
+     * @throws LayoutMetricsFailed
+     */
+    public function getMetrics()
+    {
+        if (!$this->response) {
+            $this->waitForResponse();
+        }
+
+        return $this->response['result'];
+    }
+
+    /**
+     * Returns size of scrollable area
+     * @return array
+     * @throws LayoutMetricsFailed
+     */
+    public function getContentSize()
+    {
+        if (!$this->response) {
+            $this->waitForResponse();
+        }
+
+        return $this->response->getResultData('contentSize');
+    }
+
+    /**
+     * Returns metrics relating to the layout viewport
+     * @return array
+     * @throws LayoutMetricsFailed
+     */
+    public function getLayoutViewport()
+    {
+        if (!$this->response) {
+            $this->waitForResponse();
+        }
+
+        return $this->response->getResultData('layoutViewport');
+    }
+
+    /**
+     * Returns metrics relating to the visual viewport
+     * @return array
+     * @throws LayoutMetricsFailed
+     */
+    public function getVisualViewport()
+    {
+        if (!$this->response) {
+            $this->waitForResponse();
+        }
+
+        return $this->response->getResultData('visualViewport');
+    }
+}

--- a/test/suites/PageTest.php
+++ b/test/suites/PageTest.php
@@ -102,4 +102,56 @@ class PageTest extends BaseTestCase
         $this->assertEquals(null, $fooValue);
         $this->assertEquals(null, $barValue);
     }
+
+    public function testGetLayoutMetrics()
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser([
+            'windowSize' => [500, 500]
+        ]);
+
+        $page = $browser->createPage();
+
+        $page->setViewport(100, 300)->await();
+
+        $metrics = $page->getLayoutMetrics();
+
+        $contentSize = $metrics->getContentSize();
+        $layoutViewport = $metrics->getLayoutViewport();
+        $visualViewport = $metrics->getVisualViewport();
+
+        $this->assertEquals(
+            [
+                'x' => 0,
+                'y' => 0,
+                'width' => 100,
+                'height' => 300,
+            ],
+            $contentSize
+        );
+
+        $this->assertEquals(
+            [
+                'pageX' => 0,
+                'pageY' => 0,
+                'clientWidth' => 100,
+                'clientHeight' => 300,
+            ],
+            $layoutViewport
+        );
+
+        $this->assertEquals(
+            [
+                'offsetX' => 0,
+                'offsetY' => 0,
+                'pageX' => 0,
+                'pageY' => 0,
+                'clientWidth' => 100,
+                'clientHeight' => 300,
+                'scale' => 1,
+            ],
+            $visualViewport
+        );
+    }
 }


### PR DESCRIPTION
The missing `Page.getLayoutMetrics` feature is the only thing that prevents taking full-size screenshots.