### PR TITLE
Add option timeout for Page::getFullPageClip

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -375,11 +375,12 @@ class Page
      *      ->saveToFile('/tmp/image.jpg');
      * ```
      *
+     * @param int|null $timeout
      * @return Clip
      */
-    public function getFullPageClip(): Clip
+    public function getFullPageClip(int $timeout = null): Clip
     {
-        $contentSize = $this->getLayoutMetrics()->await()->getContentSize();
+        $contentSize = $this->getLayoutMetrics()->await($timeout)->getContentSize();
         return new Clip(0, 0, $contentSize['width'], $contentSize['height']);
     }
 


### PR DESCRIPTION
For whatever reason I constantly getting timeouts on this function when trying to take screenshot on website that loaded without images and isn't all that heavy. Default two seconds timeout is certainly not enough for me.