### PR TITLE
Fix chrome binary path for Windows OS

### DIFF
--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -31,6 +31,15 @@ class BrowserFactory
             }
         }
 
+        // special path handling for Windows, try to use a shell-safe (quoted) path
+        if (
+            PHP_OS === 'WINNT'
+            // has no quote in the path yet
+            && strcspn($chromeBinaries, '\'"') >= strlen($chromeBinaries)
+        ) {
+            $chromeBinaries = '"' . $chromeBinaries . '"';
+        }
+
         $this->chromeBinaries = $chromeBinaries;
     }
 


### PR DESCRIPTION
The binary path under Windows are usually like the following one.
`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`

The problem is that there is a space in the path and it causes
the glued shell command to be split accidentally. So I guess it
would be good to always use a quoted path if possible.

After patch, the following setup works on Windows.

```php
// good both before and after patching, but writing path like this is weird...
$chrome_path = '"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"';
// this is good too, only after patching
$chrome_path = 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe';

$browserFactory = new BrowserFactory($chrome_path);
```

It's really weird to ask the user to input a escaped path by the way...


## Related Issues

- https://github.com/chrome-php/headless-chromium-php/issues/82
- https://github.com/chrome-php/headless-chromium-php/issues/75#issuecomment-469103773
- https://github.com/chrome-php/headless-chromium-php/issues/8#issuecomment-404653842