### PR TITLE
Add timeout for getBase64

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -388,11 +388,12 @@ class Page
      *      ->saveToFile('/tmp/image.jpg');
      * ```
      *
+     * @param int|null $timeout
      * @return Clip
      */
-    public function getFullPageClip(): Clip
+    public function getFullPageClip(int $timeout = null): Clip
     {
-        $contentSize = $this->getLayoutMetrics()->await()->getContentSize();
+        $contentSize = $this->getLayoutMetrics()->await($timeout)->getContentSize();
         return new Clip(0, 0, $contentSize['width'], $contentSize['height']);
     }
 

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -36,9 +36,9 @@ abstract class AbstractBinaryInput
      * Get base64 representation of the file
      * @return mixed
      */
-    public function getBase64()
+    public function getBase64($timeout = null)
     {
-        $response = $this->responseReader->waitForResponse();
+        $response = $this->responseReader->waitForResponse($timeout);
 
         if (!$response->isSuccessful()) {
             throw $this->getException($response->getErrorMessage());


### PR DESCRIPTION
Needed to add a timeout to getBase64 for large images, otherwise it was taking too long to capture the screenshot and return it to the caller