### PR TITLE
Fix Symfony deprecation

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -120,7 +120,9 @@ class BrowserProcess implements LoggerAwareInterface
         $this->logger->debug('process: starting process: ' . $processString);
 
         // setup chrome process
-        $process = new Process($processString);
+        $process = method_exists(Process::class, 'fromShellCommandline')
+            ? Process::fromShellCommandline($processString)
+            : new Process($processString);
         $this->process = $process;
         // and start
         $process->start();

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -86,7 +86,9 @@ class BrowserFactory
      */
     public function getChromeVersion()
     {
-        $process = new Process($this->chromeBinaries . ' --version');
+        $process = method_exists(Process::class, 'fromShellCommandline')
+            ? Process::fromShellCommandline($this->chromeBinaries . ' --version')
+            : new Process($this->chromeBinaries . ' --version');
 
         $exitCode = $process->run();
 

--- a/test/suites/HttpEnabledTestCase.php
+++ b/test/suites/HttpEnabledTestCase.php
@@ -17,7 +17,12 @@ class HttpEnabledTestCase extends BaseTestCase
     {
         parent::setUpBeforeClass();
 
-        self::$process = new Process('php -S localhost:8083 -t ' . __DIR__ . '/../resources/static-web');
+        $command = 'php -S localhost:8083 -t ' . __DIR__ . '/../resources/static-web';
+
+        self::$process = method_exists(Process::class, 'fromShellCommandline')
+            ? Process::fromShellCommandline($command)
+            : new Process($command);
+
         self::$process->start();
         usleep(10000); //wait for server to get going
     }


### PR DESCRIPTION
```
Passing a command as string when creating a "\Symfony\Component\Process\Process"
instance is deprecated since Symfony 4.2, pass it as an array of its arguments
instead, or use the "Process::fromShellCommandline()" constructor if you need
features provided by the shell.
```