### PR TITLE
Allow to use symfony 5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
   "require": {
     "php": ">=7.0",
 
-    "symfony/process": "^3|^4",
+    "symfony/process": "^3|^4|^5",
     "wrench/wrench": "^2.0",
-    "symfony/filesystem": "^3|^4",
+    "symfony/filesystem": "^3|^4|^5",
     "psr/log": "^1.0",
     "apix/log": "^1.2",
     "evenement/evenement": "^3.0.1"


### PR DESCRIPTION
Hey there, currently I need headless chrome on symfony 5 based project but composer.json contains requirements only for ^3|^4 versions of symfony components (such as symfony/process for example) so this small pull request will allow to use symfony 5 components as well. I tested it during last week - looks like it works great with symfony 5. Tell me if you need more information or proofs that it's works
And thanks for awesome lib!

---

Upd: 
While we're waiting for @gsouf responce - you can use my fork with this PR merged.

In your composer.json add "repositories" section with url of :

```
    "require": {
        ...
        "chrome-php/chrome": "dev-0.7.0-symfony5fix",
        ...
    },
    "repositories": {
        "chrome-php/chrome": {
            "type": "vcs",
            "url": "https://github.com/svbackend/headless-chromium-php.git"
        }
    }
```