### PR TITLE
Close browser method

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -94,11 +94,18 @@ class Browser
 
     /**
      * Closes the browser
+     *
+     * @throws \Exception
      */
     public function close()
     {
-        // TODO
-        throw new \Exception('Not implemented yet, see ProcessAwareBrowser instead');
+        // TODO check browser.close on chrome 63
+        $r = $this->connection->sendMessageSync(new Message('Browser.close'));
+        if (!$r->isSuccessful()) {
+            // log
+            $this->connection->getLogger()->debug('process: ✗ could not close gracefully');
+            throw new \Exception('cannot close, Browser.close not supported');
+        }
     }
 
     /**

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -190,14 +190,7 @@ class BrowserProcess implements LoggerAwareInterface
                     try {
                         // log
                         $this->logger->debug('process: trying to close chrome gracefully');
-
-                        // TODO check browser.close on chrome 63
-                        $r = $this->connection->sendMessageSync(new Message('Browser.close'));
-                        if (!$r->isSuccessful()) {
-                            // log
-                            $this->logger->debug('process: ✗ could not close gracefully');
-                            throw new \Exception('cannot close, Browser.close not supported');
-                        }
+                        $this->browser->close();
                     } catch (\Exception $e) {
                         //log
                         $this->logger->debug('process: closing chrome gracefully - compatibility');


### PR DESCRIPTION
I need a method for closing the browser, I work through the ``connectToBrowser`` method, I got an error, it seems to me that the 63 version is no longer relevant, you can refuse it