### PR TITLE
Handle target destroyed too fast

### DIFF
--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -12,6 +12,7 @@ use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\CommunicationException\InvalidResponse;
 use HeadlessChromium\Exception\CommunicationException\CannotReadResponse;
 use HeadlessChromium\Exception\OperationTimedOut;
+use HeadlessChromium\Exception\TargetDestroyed;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -240,6 +241,8 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         $response = $this->sendMessageSync(
             new Message('Target.attachToTarget', ['targetId' => $targetId])
         );
+        if (empty($response['result']))
+			throw new TargetDestroyed('The target was destroyed.');
         $sessionId = $response['result']['sessionId'];
         $session = new Session($targetId, $sessionId, $this);
 


### PR DESCRIPTION
By example navigating to https://browserleaks.com/canvas
and sending request on the event TargetCreated is crashing the library 

```php
$this->browser->getConnection()->on('method:Target.targetCreated', function (array $params) {
    $this->browser->getTarget($params['targetInfo']['targetId'])->getSession()->sendMessageSync(new HeadlessChromium\Communication\Message('Network.setUserAgentOverride', ['userAgent' => 'abcdef', 'platform' => 'Win32']));
});
```

causes
`Uncaught TypeError: Argument 2 passed to HeadlessChromium\Communication\Session::__construct() must be of the type string, null given, called in /....chrome-php/chrome/src/Communication/Connection.php on line 244`


This pull request detect that the call to attachToTarget failed, because It returns : 
`"error":{"code":-32602,"message":"No target with given id found"}`