### PR TITLE
Fix invalid parameters since Chrome 86

### DIFF
--- a/src/Communication/Message.php
+++ b/src/Communication/Message.php
@@ -82,7 +82,7 @@ class Message
         return json_encode([
             'id'        => $this->getId(),
             'method'    => $this->getMethod(),
-            'params'    => $this->getParams()
-        ], JSON_FORCE_OBJECT);
+            'params'    => empty($this->getParams())?new \stdClass():$this->getParams()
+        ]);
     }
 }

--- a/src/Communication/Message.php
+++ b/src/Communication/Message.php
@@ -83,6 +83,6 @@ class Message
             'id'        => $this->getId(),
             'method'    => $this->getMethod(),
             'params'    => $this->getParams()
-        ]);
+        ], JSON_FORCE_OBJECT);
     }
 }


### PR DESCRIPTION
Since chrome 86, when the library calls `Network.enable` with an empty parameters, it crashes Chrome because the empty parameter is converted to  `[]` in json, while it requires `{}`.

The library sends :
`{"id":5,"method":"Target.sendMessageToTarget","params":{"message":"{\"id\":4,\"method\":\"Network.enable\",\"params\":[]}","sessionId":"F7A65A05DA98E0D3B403344EEAB0A8BC"}}`

instead of
`{"id":5,"method":"Target.sendMessageToTarget","params":{"message":"{\"id\":4,\"method\":\"Network.enable\",\"params\":{}}","sessionId":"F7A65A05DA98E0D3B403344EEAB0A8BC"}}`

Chrome returns the following when sending `[]`: 
`"message":"{\"id\":4,\"error\":{\"code\":-32602,\"message\":\"Invalid parameters\",\"data\":\"Failed to deserialize params - CBOR: map start expected at position 6\"}`

The pull request change the behaviour of json_encode to convert empty array into an empty object instead