### PR TITLE
Implement Page::getHtml

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ $page->addScriptTag([
 $page->evaluate('$(".my.element").html()');
 ```
 
-#### Get the page html
+#### Get the page HTML
 
-You can get the page html as a string using the ```getHtml``` method.
+You can get the page HTML as a string using the ```getHtml``` method.
 
 ```php
 $html = $page->getHtml();

--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ $page->addScriptTag([
 $page->evaluate('$(".my.element").html()');
 ```
 
+#### Get the page html
+
+You can get the page html as a string using the ```getHtml``` method.
+
+```php
+$html = $page->getHtml();
+```
+
 ### Add a script to evaluate upon page navigation
 
 ```php

--- a/src/Page.php
+++ b/src/Page.php
@@ -791,7 +791,7 @@ class Page
 
     /**
      * Gets the raw html of the current page.
-     * 
+     *
      * @return String
      * @throws Exception\CommunicationException
      */

--- a/src/Page.php
+++ b/src/Page.php
@@ -792,7 +792,7 @@ class Page
     /**
      * Gets the raw html of the current page.
      *
-     * @return String
+     * @return string
      * @throws Exception\CommunicationException
      */
     public function getHtml()

--- a/src/Page.php
+++ b/src/Page.php
@@ -790,6 +790,17 @@ class Page
     }
 
     /**
+     * Gets the raw html of the current page.
+     * 
+     * @return String
+     * @throws Exception\CommunicationException
+     */
+    public function getHtml()
+    {
+        return $this->evaluate('document.documentElement.outerHTML')->getReturnValue();
+    }
+
+    /**
      * Read cookies for the current page
      *
      * usage:

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -269,7 +269,7 @@ class PageTest extends BaseTestCase
         $page = $browser->createPage();
         $page->pdf(['scale' => '2px']);
     }
-    
+
     public function testGetHtml()
     {
         $factory = new BrowserFactory();

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -269,4 +269,16 @@ class PageTest extends BaseTestCase
         $page = $browser->createPage();
         $page->pdf(['scale' => '2px']);
     }
+    
+    public function testGetHtml()
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate(self::sitePath('index.html'))->waitForNavigation();
+
+        $this->assertStringContainsString('<h1>bar</h1>', $page->getHtml());
+    }
 }


### PR DESCRIPTION
I noticed some people having trouble to get the page html, so I implemented the ```Page::getHtml``` method and added a short mention of it in the README.

Resolves #64
Resolves #100
Resolves #165