### PR TITLE
fixes phpunit assertRegExp deprecation

### DIFF
--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -26,7 +26,7 @@ class BrowserFactoryTest extends BaseTestCase
 
         $browser = $factory->createBrowser();
 
-        $this->assertRegExp('#^ws://#', $browser->getSocketUri());
+        $this->assertMatchesRegularExpression('#^ws://#', $browser->getSocketUri());
     }
 
     public function testWindowSizeOption()


### PR DESCRIPTION
Deprecation warning from PHPUnit:

> assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.