### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Here are the options available for the browser factory:
 | `enableImages`            | `true`  | Toggles loading of images                                                                    |
 | `headless`                | `true`  | Enable or disable headless mode                                                              |
 | `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                              |
-| `keepAlive`               | `true`  | true to keep alive the chrome instance when the script terminates                            |
+| `keepAlive`               | `false` | true to keep alive the chrome instance when the script terminates                            |
 | `noSandbox`               | `false` | Useful to run in a docker container                                                          |
 | `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                               |
 | `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |


### PR DESCRIPTION
Minor update to the documentation.

By default "keepAlive" is false, as confirmed both by the method's doc:
`keepAlive: true to keep alive the chrome instance when the script terminates (default: false)`
and by the code itself:
```
// instruct the runtime to kill chrome and clean temp files on exit
        if (!array_key_exists('keepAlive', $options) || !$options['keepAlive']) {
            register_shutdown_function([$browserProcess, 'kill']);
        }
```