### PR TITLE
Add parameter captureBeyondViewport to screenshot

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -423,6 +423,7 @@ class Page
      *  - format: "png"|"jpg" default "png"
      *  - quality: number from 0 to 100. Only for jpegs
      *  - clip: instance of a Clip to choose an area for the screenshot
+     *  - captureBeyondViewport: Boolean. capture the screenshot beyond the viewport. Defaults to false
      *
      * @return PageScreenshot
      * @throws CommunicationException
@@ -433,6 +434,10 @@ class Page
 
         $screenshotOptions = [];
 
+        if (array_key_exists('captureBeyondViewport', $options)) {
+            $screenshotOptions['captureBeyondViewport'] = $options['captureBeyondViewport'];
+        }        
+        
         // get format
         if (array_key_exists('format', $options)) {
             $screenshotOptions['format'] = $options['format'];

--- a/src/Page.php
+++ b/src/Page.php
@@ -423,7 +423,7 @@ class Page
      *  - format: "png"|"jpg" default "png"
      *  - quality: number from 0 to 100. Only for jpegs
      *  - clip: instance of a Clip to choose an area for the screenshot
-     *  - captureBeyondViewport: Boolean. capture the screenshot beyond the viewport. Defaults to false
+     *  - captureBeyondViewport: whether to capture the screenshot beyond the viewport. Defaults to false
      *
      * @return PageScreenshot
      * @throws CommunicationException

--- a/src/Page.php
+++ b/src/Page.php
@@ -436,8 +436,8 @@ class Page
 
         if (array_key_exists('captureBeyondViewport', $options)) {
             $screenshotOptions['captureBeyondViewport'] = $options['captureBeyondViewport'];
-        }        
-        
+        }
+
         // get format
         if (array_key_exists('format', $options)) {
             $screenshotOptions['format'] = $options['format'];


### PR DESCRIPTION
New parameter to allow to capture screenshot beyond the viewport (allowing full page screenshot) without needing to resize it.

```php
$page->screenshot(['captureBeyondViewport' => true, 'clip' => $page->getFullPageClip()])
```