### PR TITLE
Better binary path detection based on user OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ try {
 
 ### Using different chrome executable
 
-When starting the factory will look for the environment variable ``"CHROME_PATH"`` to find the chrome executable.
-If the variable is not found then it will use ``"chrome"`` as the executable.
+When starting, the factory will look for the environment variable ``"CHROME_PATH"`` to use as the chrome executable.
+If the variable is not found, it will try to guess the correct executable path according to your OS or use ``"chrome"`` as the default.
 
-You can use any executable of your choice. For instance ``"chromium-browser"``:
+You also explicitly set any executable of your choice when creating a new object. For instance ``"chromium-browser"``:
 
 ```php
 use HeadlessChromium\BrowserFactory;

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium;
+
+class AutoDiscover
+{
+    public function getChromeBinaryPath(): string
+    {
+        if (array_key_exists('CHROME_PATH', $_SERVER)) {
+            return $_SERVER['CHROME_PATH'];
+        }
+
+        switch ($this->getOS()) {
+            case 'Darwin':
+                return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+            break;
+            case 'WIN32':
+            case 'WINNT':
+            case 'Windows':
+                return self::windows();
+            break;
+        }
+
+        return 'chrome';
+    }
+
+    private static function windows(): string
+    {
+        try {
+            // accessing the registry can be costly, but this specific key is likely to be already cached in memory
+            $registryKey = shell_exec(
+                'reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" /ve'
+            );
+
+            preg_match('/.:(?!.*:).*/', $registryKey, $matches);
+
+            return $matches[0];
+        } catch (\Throwable $e) {
+            // try to guess the correct path in case the reg query fails
+            return '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
+        }
+    }
+
+    public function getOS(): string
+    {
+        return PHP_OS;
+    }
+}

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -25,20 +25,7 @@ class BrowserFactory
 
     public function __construct(string $chromeBinary = null)
     {
-        $this->chromeBinary = $chromeBinary ?? self::getDefaultChromeBinaryPath();
-    }
-
-    private static function getDefaultChromeBinaryPath(): string
-    {
-        if (array_key_exists('CHROME_PATH', $_SERVER)) {
-            return $_SERVER['CHROME_PATH'];
-        }
-
-        if (PHP_OS === 'Darwin') {
-            return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-        }
-
-        return 'chrome';
+        $this->chromeBinary = $chromeBinary ?? (new AutoDiscover())->getChromeBinaryPath();
     }
 
     /**

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\AutoDiscover;
+
+/**
+ * @covers \HeadlessChromium\AutoDiscover
+ */
+class AutoDiscoverTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        unset($_SERVER['CHROME_PATH']);
+
+        parent::setUp();
+    }
+
+    public function testExplicitEnv(): void
+    {
+        $autoDiscover = new AutoDiscover();
+
+        $_SERVER['CHROME_PATH'] = 'test-path';
+
+        $this->assertSame($_SERVER['CHROME_PATH'], $autoDiscover->getChromeBinaryPath());
+    }
+
+    public function testLinux(): void
+    {
+        $autoDiscover = $this->getMock('Linux');
+
+        $this->assertSame('chrome', $autoDiscover->getChromeBinaryPath());
+    }
+
+    public function testMac(): void
+    {
+        $autoDiscover = $this->getMock('Darwin');
+
+        $this->assertStringContainsString('.app', $autoDiscover->getChromeBinaryPath());
+    }
+
+    /**
+     * @dataProvider windowsNameProvider
+     */
+    public function testWindows($phpOS): void
+    {
+        $autoDiscover = $this->getMock($phpOS);
+
+        $this->assertStringContainsString('.exe', $autoDiscover->getChromeBinaryPath());
+    }
+
+    public function windowsNameProvider(): array
+    {
+        return [
+            ['WIN32'],
+            ['WINNT'],
+            ['Windows'],
+        ];
+    }
+
+    private function getMock($os = 'Linux'): AutoDiscover
+    {
+        /** @var AutoDiscover&\PHPUnit\Framework\MockObject\MockObject $autoDiscover */
+        $autoDiscover = $this->createPartialMock(
+            AutoDiscover::class,
+            ['getOS']
+        );
+
+        $autoDiscover->expects($this->any())->method('getOS')->willReturn($os);
+
+        return $autoDiscover;
+    }
+}

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -18,11 +18,24 @@ use HeadlessChromium\AutoDiscover;
  */
 class AutoDiscoverTest extends BaseTestCase
 {
+    private $originalEnvPath = null;
+
     protected function setUp(): void
     {
+        $this->originalEnvPath ??= $_SERVER['CHROME_PATH'];
+
         unset($_SERVER['CHROME_PATH']);
 
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['CHROME_PATH']);
+
+        if ($this->originalEnvPath !== null) $_SERVER['CHROME_PATH'] = $this->originalEnvPath;
+
+        parent::tearDown();
     }
 
     public function testExplicitEnv(): void

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -22,7 +22,7 @@ class AutoDiscoverTest extends BaseTestCase
 
     protected function setUp(): void
     {
-        $this->originalEnvPath ??= $_SERVER['CHROME_PATH'];
+        $this->originalEnvPath = null ?? $_SERVER['CHROME_PATH'];
 
         unset($_SERVER['CHROME_PATH']);
 
@@ -33,7 +33,9 @@ class AutoDiscoverTest extends BaseTestCase
     {
         unset($_SERVER['CHROME_PATH']);
 
-        if ($this->originalEnvPath !== null) $_SERVER['CHROME_PATH'] = $this->originalEnvPath;
+        if ($this->originalEnvPath !== null) {
+            $_SERVER['CHROME_PATH'] = $this->originalEnvPath;
+        }
 
         parent::tearDown();
     }


### PR DESCRIPTION
- Adds auto-detect binary path on Windows using the registry.

Following up on #206 

Even tough there are packages built specifically to handle queries to the Windows Registry, I think that adding a new dependence just for that single query is not worth it. I opted to do a simple `shell_exec` and if that fails, guess the path using an env variable.

The new class `AutoDiscover` takes this logic out of the `BrowserFactory` and makes future changes easier.

The registry query was tested only on Windows 10.