### PR TITLE
Fix getChromeVersion on windows

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -19,15 +19,12 @@ class AutoDiscover
             return $_SERVER['CHROME_PATH'];
         }
 
-        switch ($this->getOS()) {
-            case 'Darwin':
-                return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-            break;
-            case 'WIN32':
-            case 'WINNT':
-            case 'Windows':
-                return self::windows();
-            break;
+        if ($this->isMac() === true) {
+            return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+        }
+
+        if ($this->isWindows() === true) {
+            return self::windows();
         }
 
         return 'chrome';
@@ -48,6 +45,27 @@ class AutoDiscover
             // try to guess the correct path in case the reg query fails
             return '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
         }
+    }
+
+    public function isMac(): bool
+    {
+        if ($this->getOS() === 'Darwin') {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function isWindows(): bool
+    {
+        switch ($this->getOS()) {
+            case 'WIN32':
+            case 'WINNT':
+            case 'Windows':
+                return true;
+        }
+
+        return false;
     }
 
     public function getOS(): string

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -19,11 +19,11 @@ class AutoDiscover
             return $_SERVER['CHROME_PATH'];
         }
 
-        if ($this->isMac() === true) {
+        if (true === $this->isMac()) {
             return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
         }
 
-        if ($this->isWindows() === true) {
+        if (true === $this->isWindows()) {
             return self::windows();
         }
 
@@ -49,7 +49,7 @@ class AutoDiscover
 
     public function isMac(): bool
     {
-        if ($this->getOS() === 'Darwin') {
+        if ('Darwin' === $this->getOS()) {
             return true;
         }
 

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -87,13 +87,13 @@ class BrowserFactory
      */
     public function getChromeVersion()
     {
-        if ($this->autoDiscover->isWindows() === true) {
+        if (true === $this->autoDiscover->isWindows()) {
             $validWindowsPath = \str_ireplace('\\', '\\\\', $this->chromeBinary);
 
-            $version = \trim(\shell_exec('wmic datafile where name="' . $validWindowsPath . '" get Version /value'));
+            $version = \trim(\shell_exec('wmic datafile where name="'.$validWindowsPath.'" get Version /value'));
 
-            if (\stripos($version, 'Version') === false) {
-                throw new \RuntimeException('Cannot get chrome version from windows binary using "' . $this->chromeBinary . '"');
+            if (false === \stripos($version, 'Version')) {
+                throw new \RuntimeException('Cannot get chrome version from windows binary using "'.$this->chromeBinary.'"');
             }
 
             return \str_ireplace('Version=', '', $version);

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -60,6 +60,7 @@ class AutoDiscoverTest extends BaseTestCase
     {
         $autoDiscover = $this->getMock('Darwin');
 
+        $this->assertTrue($autoDiscover->isMac());
         $this->assertStringContainsString('.app', $autoDiscover->getChromeBinaryPath());
     }
 
@@ -70,6 +71,7 @@ class AutoDiscoverTest extends BaseTestCase
     {
         $autoDiscover = $this->getMock($phpOS);
 
+        $this->assertTrue($autoDiscover->isWindows());
         $this->assertStringContainsString('.exe', $autoDiscover->getChromeBinaryPath());
     }
 


### PR DESCRIPTION
The chrome `--version` flag is currently not supported on Windows. This fix uses [wmic](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmic) as a workaround to get the version directly from the .exe file.

No tests added for this specific case since it would need to run on Windows. A test mocking the `shell_exec` result wouldn't be very useful.

Fixes #214 