### PR TITLE
Add support for proxy servers as a direct option instead of relying on customFlags

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ Here are the options available for the browser factory:
 | `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |
 | `userAgent`               | none    | User agent to use for the whole browser  (see page api for alternative)                      |
 | `userDataDir`             | none    | chrome user data dir (default: a new empty dir is generated temporarily)                     |
-| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                  |
+| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
+| `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)  |
 
 ### Browser API
 

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -355,6 +355,11 @@ class BrowserProcess implements LoggerAwareInterface
             $args[] = '--ignore-certificate-errors';
         }
 
+        // proxy server
+        if (array_key_exists('proxyServer', $options)) {
+            $args[] = '--proxy-server=' . $options['proxyServer'];
+        }
+
         // add custom flags
         if (\array_key_exists('customFlags', $options) && \is_array($options['customFlags'])) {
             $args = \array_merge($args, $options['customFlags']);

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -356,7 +356,7 @@ class BrowserProcess implements LoggerAwareInterface
         }
 
         // proxy server
-        if (array_key_exists('proxyServer', $options)) {
+        if (\array_key_exists('proxyServer', $options)) {
             $args[] = '--proxy-server=' . $options['proxyServer'];
         }
 

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -357,7 +357,7 @@ class BrowserProcess implements LoggerAwareInterface
 
         // proxy server
         if (\array_key_exists('proxyServer', $options)) {
-            $args[] = '--proxy-server=' . $options['proxyServer'];
+            $args[] = '--proxy-server='.$options['proxyServer'];
         }
 
         // add custom flags

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -45,7 +45,7 @@ class BrowserFactory
      *                       - userAgent: user agent to use for the browser
      *                       - userDataDir: chrome user data dir (default: a new empty dir is generated temporarily)
      *                       - windowSize: size of the window, ex: [1920, 1080] (default: none)
-     *
+     *                       - proxyServer: a proxy server, ex: 127.0.0.1:8080 (default: none)
      * @return ProcessAwareBrowser a Browser instance to interact with the new chrome process
      */
     public function createBrowser(array $options = []): ProcessAwareBrowser

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -46,6 +46,7 @@ class BrowserFactory
      *                       - userDataDir: chrome user data dir (default: a new empty dir is generated temporarily)
      *                       - windowSize: size of the window, ex: [1920, 1080] (default: none)
      *                       - proxyServer: a proxy server, ex: 127.0.0.1:8080 (default: none)
+     *
      * @return ProcessAwareBrowser a Browser instance to interact with the new chrome process
      */
     public function createBrowser(array $options = []): ProcessAwareBrowser


### PR DESCRIPTION
Closes https://github.com/chrome-php/headless-chromium-php/issues/30

I tried to come up with a meaningful test for a while but I couldn't find a way to evaluate the proxy setting from the browser or page instances. If you have any tips on how to test this, I'll gladly implement them.