### PR TITLE
Add support for keyboard key combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $browser = $browserFactory->createBrowser([
 Here are the options available for the browser factory:
 
 | Option name               | Default | Description                                                                                  |
-|---------------------------|---------|----------------------------------------------------------------------------------------------|
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------- |
 | `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                 |
 | `customFlags`             | none    | Array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`       |
 | `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages |
@@ -148,7 +148,7 @@ Here are the options available for the browser factory:
 | `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |
 | `userAgent`               | none    | User agent to use for the whole browser  (see page api for alternative)                      |
 | `userDataDir`             | none    | chrome user data dir (default: a new empty dir is generated temporarily)                     |
-| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                  |
+| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
 
 ### Browser API
 
@@ -475,6 +475,36 @@ To impersonate a real user you may want to add a delay between each keystroke us
 ```php
 $page->keyboard()->setKeyInterval(10); // sets a delay of 10 miliseconds between keystrokes
 ```
+
+#### Key combinations
+
+The methods `press`, `type` and `release` can be used to send key combinations such as `ctrl + v`.
+
+```php
+// ctrl + a to select all text
+$page->keyboard()
+    ->press(' control ') // key names are case insensitive and trimmed
+        ->type('a') // press and release
+    ->release('Control');
+
+// ctrl + c to copy and ctrl + v to paste it twice
+$page->keyboard()
+    ->press('Ctrl') // alias for Control
+        ->type('c')
+        ->type('V') // upper and lower case should behave the same way
+    ->release(); // release all
+```
+
+You can press the same key several times in sequence, this is equivalent of a user pressing and holding the key. The release event, however, will be sent only once per key.
+
+#### Key aliases
+
+| Key     | Aliases                  |
+| :------ | :----------------------- |
+| Control | `Control`, `Ctrl`, `Ctr` |
+| Alt     | `Alt`, `AltGr`, `Alt Gr` |
+| Meta    | `Meta`, `Command`, `Cmd` |
+| Shift   | `Shift`                  |
 
 ### Cookie API
 

--- a/src/Input/Key.php
+++ b/src/Input/Key.php
@@ -18,9 +18,9 @@ namespace HeadlessChromium\Input;
  */
 abstract class Key
 {
-    public const ALT     = 1;
+    public const ALT = 1;
     public const CONTROL = 2;
-    public const META    = 4;
-    public const SHIFT   = 8;
+    public const META = 4;
+    public const SHIFT = 8;
     public const COMMAND = self::META;
 }

--- a/src/Input/Key.php
+++ b/src/Input/Key.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Input;
+
+/**
+ * Holds key constants and their respective bit values.
+ *
+ * @see https://chromedevtools.github.io/devtools-protocol/1-2/Input/
+ */
+abstract class Key
+{
+    public const ALT     = 1;
+    public const CONTROL = 2;
+    public const META    = 4;
+    public const SHIFT   = 8;
+    public const COMMAND = self::META;
+}

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -39,7 +39,7 @@ class Keyboard
     /**
      * Type a text string, char by char, without applying modifiers.
      *
-     * @param string $text text string to be typed.
+     * @param string $text text string to be typed
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -74,7 +74,7 @@ class Keyboard
      * $page->keyboard()->typeRawKey('Tab');
      * ```
      *
-     * @param string $key single raw key to be typed.
+     * @param string $key single raw key to be typed
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -108,7 +108,7 @@ class Keyboard
      * $page->keyboard()->type('a');
      * ```
      *
-     * @param string $key single key to be typed.
+     * @param string $key single key to be typed
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -132,7 +132,7 @@ class Keyboard
      * $page->keyboard()->press('Control')->press('c'); // press ctrl + c
      * ```
      *
-     * @param string $key single key to be pressed.
+     * @param string $key single key to be pressed
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -171,7 +171,7 @@ class Keyboard
      * $page->keyboard()->release(); // release all
      * ```
      *
-     * @param string $key (optional) single key to be released.
+     * @param string $key (optional) single key to be released
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -182,8 +182,9 @@ class Keyboard
     {
         $this->page->assertNotClosed();
 
-        if ($key === null) {
+        if (null === $key) {
             $this->releaseAll();
+
             return $this;
         }
 
@@ -207,7 +208,7 @@ class Keyboard
     private function releaseAll(): self
     {
         foreach ($this->pressedKeys as $key => $value) {
-            if ($value === true) {
+            if (true === $value) {
                 $this->release($key);
             }
         }

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -16,6 +16,8 @@ use HeadlessChromium\Page;
 
 class Keyboard
 {
+    use KeyboardKeys;
+
     /**
      * @var Page
      */
@@ -35,7 +37,9 @@ class Keyboard
     }
 
     /**
-     * Type a text string, char by char.
+     * Type a text string, char by char, without applying modifiers.
+     *
+     * @param string $text text string to be typed.
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -48,15 +52,10 @@ class Keyboard
 
         $length = \strlen($text);
 
-        // apparently the first character doesn't work
-        $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
-            'type' => 'char',
-            'text' => '',
-        ]));
-
         for ($i = 0; $i < $length; ++$i) {
             $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
                 'type' => 'char',
+                'modifiers' => $this->getModifiers(),
                 'text' => $text[$i],
             ]));
 
@@ -67,7 +66,7 @@ class Keyboard
     }
 
     /**
-     * Type a single raw key wich rawKeyDown.
+     * Type a raw key using the rawKeyDown event, without sending any codes or modifiers.
      *
      * Example:
      *
@@ -75,14 +74,18 @@ class Keyboard
      * $page->keyboard()->typeRawKey('Tab');
      * ```
      *
+     * @param string $key single raw key to be typed.
+     *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      *
      * @return $this
      */
-    public function typeRawKey(string $key)
+    public function typeRawKey(string $key): self
     {
         $this->page->assertNotClosed();
+
+        $this->onKeyPress($key);
 
         $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
             'type' => 'rawKeyDown',
@@ -91,11 +94,129 @@ class Keyboard
 
         \usleep($this->sleep);
 
+        $this->release($key);
+
         return $this;
     }
 
     /**
-     * Sets the time interval between key strokes in milliseconds.
+     * Press and release a single key.
+     *
+     * Example:
+     *
+     * ```php
+     * $page->keyboard()->type('a');
+     * ```
+     *
+     * @param string $key single key to be typed.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     *
+     * @return $this
+     */
+    public function type(string $key): self
+    {
+        return $this->press($key)->release($key);
+    }
+
+    /**
+     * Press a single key with key codes and modifiers.
+     *
+     * A key can be pressed multiple times sequentially. This is what happens
+     * in a real browser when the user presses and holds down hown the key.
+     *
+     * Example:
+     *
+     * ```php
+     * $page->keyboard()->press('Control')->press('c'); // press ctrl + c
+     * ```
+     *
+     * @param string $key single key to be pressed.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     *
+     * @return $this
+     */
+    public function press(string $key): self
+    {
+        $this->page->assertNotClosed();
+
+        $this->onKeyPress($key);
+
+        $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
+            'type' => 'keyDown',
+            'modifiers' => $this->getModifiers(),
+            'text' => $key,
+            'key' => $this->getCurrentKey(),
+            'windowsVirtualKeyCode' => $this->getKeyCode(),
+        ]));
+
+        \usleep($this->sleep);
+
+        return $this;
+    }
+
+    /**
+     * Release a single key.
+     *
+     * A key is released only once, even if it was pressed multiple times.
+     * If no key is given, all pressed keys will be released.
+     *
+     * Example:
+     *
+     * ```php
+     * $page->keyboard()->release('Control'); // release Control
+     * $page->keyboard()->release(); // release all
+     * ```
+     *
+     * @param string $key (optional) single key to be released.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     *
+     * @return $this
+     */
+    public function release(string $key = null): self
+    {
+        $this->page->assertNotClosed();
+
+        if ($key === null) {
+            $this->releaseAll();
+            return $this;
+        }
+
+        $this->onKeyRelease($key);
+
+        $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
+            'type' => 'keyUp',
+            'key' => $this->getCurrentKey(),
+        ]));
+
+        \usleep($this->sleep);
+
+        return $this;
+    }
+
+    /**
+     * Release all pressed keys.
+     *
+     * @return self
+     */
+    private function releaseAll(): self
+    {
+        foreach ($this->pressedKeys as $key => $value) {
+            if ($value === true) {
+                $this->release($key);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the time interval between key strokes in milliseconds.
      *
      * @param int $milliseconds
      *

--- a/src/Input/KeyboardKeys.php
+++ b/src/Input/KeyboardKeys.php
@@ -19,7 +19,7 @@ namespace HeadlessChromium\Input;
 trait KeyboardKeys
 {
     /**
-     * Array of currently pressed keys (keyDown events)
+     * Array of currently pressed keys (keyDown events).
      *
      * The elements of this array should be unique. A real keyboard can create several keyDown events
      * by holding down a key, but only one keyUp event will be sent when the key is released.
@@ -39,7 +39,7 @@ trait KeyboardKeys
     protected $modifiers = 0;
 
     /**
-     * Aliases for modifier keys, in lowercase
+     * Aliases for modifier keys, in lowercase.
      */
     protected $keyAliases = [
         Key::ALT => [
@@ -59,13 +59,13 @@ trait KeyboardKeys
         ],
         Key::SHIFT => [
             'shift',
-        ]
+        ],
     ];
 
     /**
      * Register a pressed key and apply modifiers.
      *
-     * @param string $key pressed key.
+     * @param string $key pressed key
      *
      * @return void
      */
@@ -73,7 +73,7 @@ trait KeyboardKeys
     {
         $this->setCurrentKey($key);
 
-        if ($this->isKeyPressed() === true) {
+        if (true === $this->isKeyPressed()) {
             return;
         }
 
@@ -85,7 +85,7 @@ trait KeyboardKeys
     /**
      * Register a released key and remove modifiers.
      *
-     * @param string $key released key.
+     * @param string $key released key
      *
      * @return void
      */
@@ -93,7 +93,7 @@ trait KeyboardKeys
     {
         $this->setCurrentKey($key);
 
-        if ($this->isKeyPressed() === false) {
+        if (false === $this->isKeyPressed()) {
             return;
         }
 
@@ -113,10 +113,10 @@ trait KeyboardKeys
      */
     protected function toggleModifierFromKey(): void
     {
-        $key = strtolower($this->currentKey);
+        $key = \strtolower($this->currentKey);
 
         foreach ($this->keyAliases as $modifier => $aliases) {
-            if (\in_array($key, $aliases) === true) {
+            if (true === \in_array($key, $aliases)) {
                 $this->toggleModifier($modifier);
                 break;
             }
@@ -135,7 +135,7 @@ trait KeyboardKeys
      *   0101
      * & 0100
      * = 0100
-
+     *
      *   0101
      * & 0010
      * = 0000
@@ -148,6 +148,7 @@ trait KeyboardKeys
     {
         if (($this->modifiers & $bit) === $bit) {
             $this->modifiers &= ~$bit;
+
             return;
         }
 
@@ -157,7 +158,7 @@ trait KeyboardKeys
     /**
      * Check if the current key was pressed and not released yet.
      *
-     * @return boolean true if they key is listed as pressed.
+     * @return bool true if they key is listed as pressed
      */
     protected function isKeyPressed(): bool
     {
@@ -167,7 +168,7 @@ trait KeyboardKeys
     /**
      * Return the current key code.
      *
-     * @return integer the key code.
+     * @return int the key code
      */
     public function getKeyCode(): int
     {
@@ -178,7 +179,7 @@ trait KeyboardKeys
      * Return the current bit modifier.
      * The browser expects to receive this value as int.
      *
-     * @return integer current bit modifier
+     * @return int current bit modifier
      */
     public function getModifiers(): int
     {
@@ -188,7 +189,7 @@ trait KeyboardKeys
     /**
      * Return the current key being processed.
      *
-     * @return string the current key.
+     * @return string the current key
      */
     public function getCurrentKey(): string
     {
@@ -198,7 +199,7 @@ trait KeyboardKeys
     /**
      * Return the list of unique pressed keys that were not released yet.
      *
-     * @return array list of pressed keys.
+     * @return array list of pressed keys
      */
     public function getPressedKeys(): array
     {
@@ -211,7 +212,7 @@ trait KeyboardKeys
      * Single character keys must be in uppercase, otherwhie things like ctrl + v won't work.
      * Triming the string will also prevent future mistakes during normal usage.
      *
-     * @param string $key key to be set as current.
+     * @param string $key key to be set as current
      *
      * @return void
      */

--- a/src/Input/KeyboardKeys.php
+++ b/src/Input/KeyboardKeys.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Input;
+
+/**
+ * Translates typed keys to their respective codes.
+ *
+ * @see https://chromedevtools.github.io/devtools-protocol/1-2/Input/
+ */
+trait KeyboardKeys
+{
+    /**
+     * Array of currently pressed keys (keyDown events)
+     *
+     * The elements of this array should be unique. A real keyboard can create several keyDown events
+     * by holding down a key, but only one keyUp event will be sent when the key is released.
+     */
+    protected $pressedKeys = [];
+
+    /**
+     * Current key as a sanitized string.
+     *
+     * Single letters like "v" must be in uppercase, otherwise key combinations like ctrl + v won't work.
+     */
+    protected $currentKey = '';
+
+    /**
+     * Bit field representing pressed modifier keys.
+     */
+    protected $modifiers = 0;
+
+    /**
+     * Aliases for modifier keys, in lowercase
+     */
+    protected $keyAliases = [
+        Key::ALT => [
+            'alt',
+            'altgr',
+            'alt gr',
+        ],
+        Key::CONTROL => [
+            'control',
+            'ctrl',
+            'ctr',
+        ],
+        Key::META => [
+            'meta',
+            'command',
+            'cmd',
+        ],
+        Key::SHIFT => [
+            'shift',
+        ]
+    ];
+
+    /**
+     * Register a pressed key and apply modifiers.
+     *
+     * @param string $key pressed key.
+     *
+     * @return void
+     */
+    protected function onKeyPress(string $key): void
+    {
+        $this->setCurrentKey($key);
+
+        if ($this->isKeyPressed() === true) {
+            return;
+        }
+
+        $this->pressedKeys[$this->currentKey] = true;
+
+        $this->toggleModifierFromKey();
+    }
+
+    /**
+     * Register a released key and remove modifiers.
+     *
+     * @param string $key released key.
+     *
+     * @return void
+     */
+    protected function onKeyRelease(string $key): void
+    {
+        $this->setCurrentKey($key);
+
+        if ($this->isKeyPressed() === false) {
+            return;
+        }
+
+        unset($this->pressedKeys[$this->currentKey]);
+
+        $this->toggleModifierFromKey();
+    }
+
+    /**
+     * Check the current key against the list of aliases.
+     * If it match, try to add or remove its bits to the modifier.
+     *
+     * @see self::$keyAliases
+     * @see self::$modifiers
+     *
+     * @return void
+     */
+    protected function toggleModifierFromKey(): void
+    {
+        $key = strtolower($this->currentKey);
+
+        foreach ($this->keyAliases as $modifier => $aliases) {
+            if (\in_array($key, $aliases) === true) {
+                $this->toggleModifier($modifier);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Perform bit operations to add or remove bits from the modifier.
+     *
+     * Examples:
+     *
+     *   0001
+     * | 0100
+     * = 0101
+     *
+     *   0101
+     * & 0100
+     * = 0100
+
+     *   0101
+     * & 0010
+     * = 0000
+     *
+     * @see self::$modifiers
+     *
+     * @return void
+     */
+    protected function toggleModifier(int $bit): void
+    {
+        if (($this->modifiers & $bit) === $bit) {
+            $this->modifiers &= ~$bit;
+            return;
+        }
+
+        $this->modifiers |= $bit;
+    }
+
+    /**
+     * Check if the current key was pressed and not released yet.
+     *
+     * @return boolean true if they key is listed as pressed.
+     */
+    protected function isKeyPressed(): bool
+    {
+        return \array_key_exists($this->currentKey, $this->pressedKeys);
+    }
+
+    /**
+     * Return the current key code.
+     *
+     * @return integer the key code.
+     */
+    public function getKeyCode(): int
+    {
+        return \ord($this->currentKey);
+    }
+
+    /**
+     * Return the current bit modifier.
+     * The browser expects to receive this value as int.
+     *
+     * @return integer current bit modifier
+     */
+    public function getModifiers(): int
+    {
+        return $this->modifiers;
+    }
+
+    /**
+     * Return the current key being processed.
+     *
+     * @return string the current key.
+     */
+    public function getCurrentKey(): string
+    {
+        return $this->currentKey;
+    }
+
+    /**
+     * Return the list of unique pressed keys that were not released yet.
+     *
+     * @return array list of pressed keys.
+     */
+    public function getPressedKeys(): array
+    {
+        return $this->pressedKeys;
+    }
+
+    /**
+     * Set a key as the current key.
+     *
+     * Single character keys must be in uppercase, otherwhie things like ctrl + v won't work.
+     * Triming the string will also prevent future mistakes during normal usage.
+     *
+     * @param string $key key to be set as current.
+     *
+     * @return void
+     */
+    protected function setCurrentKey(string $key): void
+    {
+        $this->currentKey = \ucfirst(\trim($key));
+    }
+}

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -145,7 +145,7 @@ class KeyboardApiTest extends BaseTestCase
             ->press('b')
             ->release();
 
-        $this->assertEquals(0, count($page->keyboard()->getPressedKeys()));
+        $this->assertEquals(0, \count($page->keyboard()->getPressedKeys()));
     }
 
     /**

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -15,8 +15,7 @@ use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
 
 /**
- * @covers \HeadlessChromium\Browser
- * @covers \HeadlessChromium\Page
+ * @covers \HeadlessChromium\Input\Keyboard
  */
 class KeyboardApiTest extends BaseTestCase
 {
@@ -56,7 +55,7 @@ class KeyboardApiTest extends BaseTestCase
         $page = $this->openSitePage('form.html');
 
         $page->keyboard()
-            ->typeRawKey('Tab')
+            ->type('Tab')
             ->typeText('bar');
 
         $value = $page
@@ -92,6 +91,61 @@ class KeyboardApiTest extends BaseTestCase
             ->getReturnValue();
 
         $this->assertTrue($value);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testTypeKeyCombinations(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('form.html');
+
+        $text = 'bar';
+
+        // select an input and type a random text
+        $page->keyboard()
+            ->typeRawKey('Tab')
+            ->typeText($text);
+
+        // select all the text using ctrl + a
+        $page->keyboard()
+            ->press(' control ') // key names should be case insensitive and trimmed
+                ->type('a')
+            ->release('Control');
+
+        // type ctrl + c to copy the selected text and paste it twice with ctrl + v
+        $page->keyboard()
+            ->press('Ctrl') // aliases sould work
+                ->type('c')
+                ->type('V') // upper and lower case should behave the same way
+                ->type('v')
+            ->release();
+
+        $value = $page
+            ->evaluate('document.querySelector("#myinput").value;')
+            ->getReturnValue();
+
+        // check if the input contains the typed text twice
+        $this->assertEquals($text.$text, $value);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testReleaseAll(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('form.html');
+
+        $page->keyboard()
+            ->press('a')
+            ->press('b')
+            ->release();
+
+        $this->assertEquals(0, count($page->keyboard()->getPressedKeys()));
     }
 
     /**

--- a/tests/KeyboardForTests.php
+++ b/tests/KeyboardForTests.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\Input\KeyboardKeys;
+
+class KeyboardForTests
+{
+    use KeyboardKeys {
+        onKeyPress            as public;
+        onKeyRelease          as public;
+        toggleModifierFromKey as public;
+        toggleModifier        as public;
+        isKeyPressed          as public;
+        setCurrentKey         as public;
+    }
+}

--- a/tests/KeyboardKeysTest.php
+++ b/tests/KeyboardKeysTest.php
@@ -27,8 +27,8 @@ class KeyboardKeysTest extends BaseTestCase
     {
         return [
             // Key,   expectedKey
-            ['a',     'A'  ],
-            ['A',     'A'  ],
+            ['a',     'A'],
+            ['A',     'A'],
             ['key',   'Key'],
             [' KEY ', 'KEY'],
         ];
@@ -74,13 +74,13 @@ class KeyboardKeysTest extends BaseTestCase
 
         $this->assertEquals($expectedKey, $this->keyboard->getCurrentKey());
         $this->assertEquals(0, $this->keyboard->getModifiers());
-        $this->assertEquals(1, count($this->keyboard->getPressedKeys()));
+        $this->assertEquals(1, \count($this->keyboard->getPressedKeys()));
         $this->assertTrue($this->keyboard->isKeyPressed());
 
         $this->keyboard->onKeyRelease($key);
 
         $this->assertEquals($expectedKey, $this->keyboard->getCurrentKey());
-        $this->assertEquals(0, count($this->keyboard->getPressedKeys()));
+        $this->assertEquals(0, \count($this->keyboard->getPressedKeys()));
         $this->assertEquals(0, $this->keyboard->getModifiers());
         $this->assertFalse($this->keyboard->isKeyPressed());
     }

--- a/tests/KeyboardKeysTest.php
+++ b/tests/KeyboardKeysTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+/**
+ * @covers \HeadlessChromium\Input\KeyboardKeys
+ */
+class KeyboardKeysTest extends BaseTestCase
+{
+    private $keyboard;
+
+    protected function setUp(): void
+    {
+        $this->keyboard = new KeyboardForTests();
+    }
+
+    public function keyProvider(): array
+    {
+        return [
+            // Key,   expectedKey
+            ['a',     'A'  ],
+            ['A',     'A'  ],
+            ['key',   'Key'],
+            [' KEY ', 'KEY'],
+        ];
+    }
+
+    public function modifierKeyProvider(): array
+    {
+        return [
+            // Key,     expectedModifier
+            ['Alt',     1],
+            ['AltGr',   1],
+            ['Alt Gr',  1],
+
+            ['Control', 2],
+            ['ctrl',    2],
+            ['Ctr',     2],
+
+            ['Meta',    4],
+            ['Cmd',     4],
+            ['Command', 4],
+
+            ['Shift',   8],
+        ];
+    }
+
+    public function keyCodesProvider(): array
+    {
+        return [
+            ['a', 65],
+            ['A', 65],
+        ];
+    }
+
+    /**
+     * @dataProvider keyProvider
+     */
+    public function testOnKeyPressAndRelease($key, $expectedKey): void
+    {
+        $this->assertFalse($this->keyboard->isKeyPressed());
+        $this->assertEquals(0, $this->keyboard->getModifiers());
+
+        $this->keyboard->onKeyPress($key);
+
+        $this->assertEquals($expectedKey, $this->keyboard->getCurrentKey());
+        $this->assertEquals(0, $this->keyboard->getModifiers());
+        $this->assertEquals(1, count($this->keyboard->getPressedKeys()));
+        $this->assertTrue($this->keyboard->isKeyPressed());
+
+        $this->keyboard->onKeyRelease($key);
+
+        $this->assertEquals($expectedKey, $this->keyboard->getCurrentKey());
+        $this->assertEquals(0, count($this->keyboard->getPressedKeys()));
+        $this->assertEquals(0, $this->keyboard->getModifiers());
+        $this->assertFalse($this->keyboard->isKeyPressed());
+    }
+
+    /**
+     * @dataProvider modifierKeyProvider
+     */
+    public function testToggleModifierFromKey($key, $expectedModifier): void
+    {
+        $this->keyboard->setCurrentKey($key);
+        $this->keyboard->toggleModifierFromKey();
+
+        $this->keyboard->setCurrentKey('NonModifierKey');
+        $this->keyboard->toggleModifierFromKey();
+
+        $this->assertEquals($expectedModifier, $this->keyboard->getModifiers());
+
+        $this->keyboard->setCurrentKey($key);
+        $this->keyboard->toggleModifierFromKey();
+        $this->assertEquals(0, $this->keyboard->getModifiers());
+    }
+
+    public function testToggleModifier(): void
+    {
+        $this->keyboard->toggleModifier(0b0001);
+        $this->keyboard->toggleModifier(0b0010);
+
+        $this->assertEquals(0b0011, $this->keyboard->getModifiers());
+
+        $this->keyboard->toggleModifier(0b0010);
+
+        $this->assertEquals(0b0001, $this->keyboard->getModifiers());
+    }
+
+    /**
+     * @dataProvider keyCodesProvider
+     */
+    public function testGetKeyCode($key, $code): void
+    {
+        $this->keyboard->setCurrentKey($key);
+
+        $this->assertEquals($code, $this->keyboard->getKeyCode());
+    }
+}


### PR DESCRIPTION
Add methods to explicitly send `keyDown` and `keyUp` events and parse special keys to send the proper modifier bit. This will allow key combinations such as `ctrl + v`.

Further work will be done to use this feature in with single method, like `type('ctrl + v');`, and use constants instead of aliases, like `type(Key::CONTROL);`

Resolves #231 