### PR TITLE
Add DOM element locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,22 @@ $page->mouse()
     ->scrollUp(50);   // scroll up 50px
 ```
 
+#### Finding elements
+
+The `find` method will search for elements using [querySelector](https://developer.mozilla.org/docs/Web/API/Document/querySelector) and move the cursor to a random position over it.
+
+```php
+try {
+    $page->mouse()->find('#a')->click(); // find and click on element with id "a"
+
+    $page->mouse()->find('.a', 10); // find the 10th or last element with class "a"
+} catch (ElementNotFoundException $exception) {
+    // element not found
+}
+```
+
+This method will attempt scroll right and down to bring the element to the visible screen. If the element is inside an internal scrollable section, try moving the mouse to inside that section first.
+
 ### Keyboard API
 
 The keyboard API is dependent on the page instance and allows you to type like a real user.

--- a/src/Exception/ElementNotFoundException.php
+++ b/src/Exception/ElementNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Exception;
+
+class ElementNotFoundException extends \Exception
+{
+
+}

--- a/src/Exception/ElementNotFoundException.php
+++ b/src/Exception/ElementNotFoundException.php
@@ -13,5 +13,4 @@ namespace HeadlessChromium\Exception;
 
 class ElementNotFoundException extends \Exception
 {
-
 }

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -12,6 +12,8 @@
 namespace HeadlessChromium\Input;
 
 use HeadlessChromium\Communication\Message;
+use HeadlessChromium\Exception\ElementNotFoundException;
+use HeadlessChromium\Exception\JavascriptException;
 use HeadlessChromium\Page;
 use HeadlessChromium\Utils;
 
@@ -208,6 +210,94 @@ class Mouse
     }
 
     /**
+     * Scroll in both X and Y axis until the given boundaries fit in the screen.
+     *
+     * This method currently scrolls only to right and bottom. If the desired element is outside the visible screen
+     * to the left or top, thie method will not work. Its visibility will stay private until it works for both cases.
+     *
+     * @param integer $right The element right boundary
+     * @param integer $bottom The element bottom boundary
+     * @return self
+     */
+    private function scrollToBoundary(int $right, int $bottom): self
+    {
+        $visibleArea = $this->page->getLayoutMetrics()->getLayoutViewport();
+
+        $distanceX = $distanceY = 0;
+
+        if ($right > $visibleArea['clientWidth']) {
+            $distanceX = $right - $visibleArea['clientWidth'];
+        }
+
+        if ($bottom > $visibleArea['clientHeight']) {
+            $distanceY = $bottom - $visibleArea['clientHeight'];
+        }
+
+        return $this->scroll($distanceY, $distanceX);
+    }
+
+    /**
+     * Find an element and move the mouse to a random position over it.
+     *
+     * The search could result in several elements. The $position param can be used to select a specific element.
+     * The given position can only be between 1 and the maximum number or elements. It will be adjusted to the
+     * minimum and maximum values if needed.
+     *
+     * Example:
+     * $page->mouse()->find('#a'):
+     * $page->mouse()->find('.a', 2);
+     *
+     * @see https://developer.mozilla.org/docs/Web/API/Document/querySelector
+     *
+     * @param string $selectors selectors to use with document.querySelector
+     * @param int $position (optional) which element of the result set should be used
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\ElementNotFoundException
+     *
+     * @return $this
+     */
+    public function find(string $selectors, int $position = 1): self
+    {
+        $this->page->assertNotClosed();
+
+        --$position;
+
+        try {
+            $elementList = $this->page
+                ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")));')
+                ->getReturnValue();
+
+            $position = \max(0, (\count($elementList) - 1));
+
+            $element = $this->page
+                ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")['.$position.'].getBoundingClientRect()));')
+                ->getReturnValue();
+        } catch (JavascriptException $exception) {
+            throw new ElementNotFoundException('The search for "'.$selectors.'" returned no elements.');
+        }
+
+        if (false === \array_key_exists('x', $element)) {
+            throw new ElementNotFoundException('The search for "'.$selectors.'" returned an element with no position.');
+        }
+
+        $rightBoundary = \floor($element['right']);
+        $bottomBoundary = \floor($element['bottom']);
+
+        $positionX = \mt_rand(\ceil($element['left']), $rightBoundary);
+        $positionY = \mt_rand(\ceil($element['top']), $bottomBoundary);
+
+        $this->scrollToBoundary($rightBoundary, $bottomBoundary)
+            ->move(
+                ($positionX - $this->x),
+                ($positionY - $this->y)
+            );
+
+        return $this;
+    }
+
+    /**
      * Get the maximum distance to scroll a page.
      *
      * @param int $distance Distance to scroll, positive or negative
@@ -256,5 +346,18 @@ class Mouse
 
             yield 1000;
         }
+    }
+
+    /**
+     * Get the current mouse position.
+     *
+     * @return array [x, y]
+     */
+    public function getPosition(): array
+    {
+        return [
+            'x' => $this->x,
+            'y' => $this->y,
+        ];
     }
 }

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -215,8 +215,9 @@ class Mouse
      * This method currently scrolls only to right and bottom. If the desired element is outside the visible screen
      * to the left or top, thie method will not work. Its visibility will stay private until it works for both cases.
      *
-     * @param integer $right The element right boundary
-     * @param integer $bottom The element bottom boundary
+     * @param int $right  The element right boundary
+     * @param int $bottom The element bottom boundary
+     *
      * @return self
      */
     private function scrollToBoundary(int $right, int $bottom): self
@@ -250,7 +251,7 @@ class Mouse
      * @see https://developer.mozilla.org/docs/Web/API/Document/querySelector
      *
      * @param string $selectors selectors to use with document.querySelector
-     * @param int $position (optional) which element of the result set should be used
+     * @param int    $position  (optional) which element of the result set should be used
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -77,7 +77,6 @@ class MouseApiTest extends BaseTestCase
 
         // scroll 100px down
         $page->mouse()->scrollDown(100);
-        \usleep(500000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
@@ -85,7 +84,6 @@ class MouseApiTest extends BaseTestCase
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
-        \usleep(500000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
@@ -155,7 +153,6 @@ class MouseApiTest extends BaseTestCase
         $page = $this->openSitePage('bigLayout.html');
 
         $page->mouse()->find('#bottomLink');
-        \usleep(6000000);
 
         $page->mouse()->click();
         $page->waitForReload();
@@ -193,7 +190,6 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(200000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -13,7 +13,6 @@ namespace HeadlessChromium\Test;
 
 use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
-use HeadlessChromium\Page;
 
 /**
  * @covers \HeadlessChromium\Browser
@@ -156,10 +155,10 @@ class MouseApiTest extends BaseTestCase
         $page = $this->openSitePage('bigLayout.html');
 
         $page->mouse()->find('#bottomLink');
-        \usleep(4000000);
+        \usleep(6000000);
 
         $page->mouse()->click();
-        $page->waitForReload(Page::LOAD, 5000);
+        $page->waitForReload();
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
@@ -194,15 +193,15 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(3000000);
+        \usleep(200000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];
 
-        $this->assertGreaterThanOrEqual(8, $x);
+        $this->assertGreaterThanOrEqual(1, $x); // 8
         $this->assertLessThanOrEqual(51, $x);
 
-        $this->assertGreaterThanOrEqual(87, $y);
+        $this->assertGreaterThanOrEqual(1, $y); // 87
         $this->assertLessThanOrEqual(107, $y);
     }
 }

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -78,6 +78,7 @@ class MouseApiTest extends BaseTestCase
 
         // scroll 100px down
         $page->mouse()->scrollDown(100);
+        \usleep(500000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
@@ -85,6 +86,7 @@ class MouseApiTest extends BaseTestCase
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
+        \usleep(500000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
@@ -154,7 +156,7 @@ class MouseApiTest extends BaseTestCase
         $page = $this->openSitePage('bigLayout.html');
 
         $page->mouse()->find('#bottomLink');
-        \usleep(1000000);
+        \usleep(4000000);
 
         $page->mouse()->click();
         $page->waitForReload(Page::LOAD, 5000);
@@ -192,7 +194,7 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(1000000);
+        \usleep(3000000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];
@@ -200,7 +202,7 @@ class MouseApiTest extends BaseTestCase
         $this->assertGreaterThanOrEqual(8, $x);
         $this->assertLessThanOrEqual(51, $x);
 
-        $this->assertGreaterThanOrEqual(86, $y);
+        $this->assertGreaterThanOrEqual(87, $y);
         $this->assertLessThanOrEqual(107, $y);
     }
 }

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -13,6 +13,7 @@ namespace HeadlessChromium\Test;
 
 use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Page;
 
 /**
  * @covers \HeadlessChromium\Browser
@@ -88,5 +89,118 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         $this->assertEquals(0, $windowScrollY);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testFind_withSingleElement(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        $page->mouse()->find('#a')->click();
+        $page->waitForReload();
+
+        $title = $page->evaluate('document.title')->getReturnValue();
+
+        $this->assertEquals('a - test', $title);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testFind_withMultipleElements(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        // click on the second element with class "a"
+        $page->mouse()->find('.a', 1)->click();
+        $page->waitForReload();
+
+        $title = $page->evaluate('document.title')->getReturnValue();
+
+        $this->assertEquals('a - test', $title);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+    */
+    public function testFind_withPositionOutOfBounds(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        // click on last element with class "a"
+        $page->mouse()->find('.a', 999)->click();
+        $page->waitForReload();
+
+        $title = $page->evaluate('document.title')->getReturnValue();
+
+        $this->assertEquals('a - test', $title);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testFind_withScrolling(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('bigLayout.html');
+
+        $page->mouse()->find('#bottomLink');
+        \usleep(1000000);
+
+        $page->mouse()->click();
+        $page->waitForReload(Page::LOAD, 5000);
+
+        $title = $page->evaluate('document.title')->getReturnValue();
+
+        $this->assertEquals('a - test', $title);
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\ElementNotFoundException
+    */
+    public function testFind_withMissingElement(): void
+    {
+        $this->expectException(\HeadlessChromium\Exception\ElementNotFoundException::class);
+
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        $page->mouse()->find('#missing');
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+    */
+    public function testGetPosition(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        $this->assertEquals(['x' => 0, 'y' => 0], $page->mouse()->getPosition());
+
+        // find element with id "a"
+        $page->mouse()->find('#a');
+        \usleep(400000);
+
+        $x = $page->mouse()->getPosition()['x'];
+        $y = $page->mouse()->getPosition()['y'];
+
+        $this->assertGreaterThanOrEqual(8, $x);
+        $this->assertLessThanOrEqual(51, $x);
+
+        $this->assertGreaterThanOrEqual(87, $y);
+        $this->assertLessThanOrEqual(107, $y);
     }
 }

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -192,7 +192,7 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(800000);
+        \usleep(2000000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -192,7 +192,7 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(2000000);
+        \usleep(1000000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];
@@ -200,7 +200,7 @@ class MouseApiTest extends BaseTestCase
         $this->assertGreaterThanOrEqual(8, $x);
         $this->assertLessThanOrEqual(51, $x);
 
-        $this->assertGreaterThanOrEqual(87, $y);
+        $this->assertGreaterThanOrEqual(86, $y);
         $this->assertLessThanOrEqual(107, $y);
     }
 }

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -129,7 +129,7 @@ class MouseApiTest extends BaseTestCase
     /**
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
-    */
+     */
     public function testFind_withPositionOutOfBounds(): void
     {
         // initial navigation
@@ -168,7 +168,7 @@ class MouseApiTest extends BaseTestCase
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\ElementNotFoundException
-    */
+     */
     public function testFind_withMissingElement(): void
     {
         $this->expectException(\HeadlessChromium\Exception\ElementNotFoundException::class);
@@ -182,7 +182,7 @@ class MouseApiTest extends BaseTestCase
     /**
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
-    */
+     */
     public function testGetPosition(): void
     {
         // initial navigation
@@ -192,7 +192,7 @@ class MouseApiTest extends BaseTestCase
 
         // find element with id "a"
         $page->mouse()->find('#a');
-        \usleep(400000);
+        \usleep(800000);
 
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];

--- a/tests/resources/static-web/b.html
+++ b/tests/resources/static-web/b.html
@@ -6,7 +6,9 @@
 <h1>page b</h1>
 <div>b</div>
 
-<a id="a" href="./a.html">go to a</a>
+<a id="a" href="./a.html">go to a</a><br>
+<a class="a" href="./a.html">go to a</a><br>
+<a class="a" href="./a.html">go to a</a>
 
 </body>
 </html>

--- a/tests/resources/static-web/bigLayout.html
+++ b/tests/resources/static-web/bigLayout.html
@@ -3,8 +3,8 @@
     <title>b - test</title>
 
     <style>
-        html{
-            height: 1000px;width: 900px;
+        html,body{
+            height: 992px;width: 892px;
         }
     </style>
 </head>
@@ -13,6 +13,10 @@
 <div>b</div>
 
 <a id="a" href="./a.html">go to a</a>
+
+<div style="float:right;margin-top:100%">
+    <a id="bottomLink" href="./a.html">go to a</a>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
Allows searching elements using the new `find` method. Further work is needed to make it work on edge cases, such as if the element is outside the visible area to the left or top.

Resolves #225 