### PR TITLE
Fix scroll method returning prematurely 

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -13,6 +13,7 @@ namespace HeadlessChromium\Input;
 
 use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Page;
+use HeadlessChromium\Utils;
 
 class Mouse
 {
@@ -162,16 +163,27 @@ class Mouse
     /**
      * Scroll a positive or negative distance using the mouseWheel event type.
      *
-     * @param int $distance Distance in pixels
+     * @param int $distanceY Distance in pixels for the Y axis
+     * @param int $distanceX (optional) Distance in pixels for the X axis
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
      *
      * @return $this
      */
-    private function scroll(int $distance)
+    private function scroll(int $distanceY, int $distanceX = 0): self
     {
         $this->page->assertNotClosed();
+
+        $scollableArea = $this->page->getLayoutMetrics()->getContentSize();
+        $visibleArea = $this->page->getLayoutMetrics()->getVisualViewport();
+
+        $distanceX = $this->getMaximumDistance($distanceX, $visibleArea['pageX'], $scollableArea['height']);
+        $distanceY = $this->getMaximumDistance($distanceY, $visibleArea['pageY'], $scollableArea['width']);
+
+        $targetX = $visibleArea['pageX'] + $distanceX;
+        $targetY = $visibleArea['pageY'] + $distanceY;
 
         // make sure the mouse is on the screen
         $this->move($this->x, $this->y);
@@ -181,13 +193,64 @@ class Mouse
             'type' => 'mouseWheel',
             'x' => $this->x,
             'y' => $this->y,
-            'deltaX' => 0,
-            'deltaY' => $distance,
+            'deltaX' => $distanceX,
+            'deltaY' => $distanceY,
         ]));
 
+        // wait until the scroll is done
+        Utils::tryWithTimeout(30000 * 1000, $this->waitForScroll($targetX, $targetY));
+
         // set new position after move
-        $this->y += $distance;
+        $this->x += $distanceX;
+        $this->y += $distanceY;
 
         return $this;
+    }
+
+    /**
+     * Get the maximum distance to scroll a page.
+     *
+     * @param int $distance Distance to scroll, positive or negative
+     * @param int $current  Current position
+     * @param int $maximum  Maximum posible distance
+     *
+     * @return int allowed distance to scroll
+     */
+    private function getMaximumDistance(int $distance, int $current, int $maximum): int
+    {
+        $result = $current + $distance;
+
+        if ($result < 0) {
+            return $distance + \abs($result);
+        }
+
+        if ($result > $maximum) {
+            return $maximum - $current;
+        }
+
+        return $distance;
+    }
+
+    /**
+     * Wait for the browser to process the scroll command.
+     *
+     * @param int $targetX
+     * @param int $targetY
+     *
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     *
+     * @return bool|\Generator
+     */
+    private function waitForScroll(int $targetX, int $targetY)
+    {
+        while (true) {
+            $visibleArea = $this->page->getLayoutMetrics()->getVisualViewport();
+
+            if ($visibleArea['pageX'] === $targetX && $visibleArea['pageY'] === $targetY) {
+                return true;
+            }
+
+            yield 1000;
+        }
     }
 }

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -234,6 +234,10 @@ class Mouse
     /**
      * Wait for the browser to process the scroll command.
      *
+     * Return the number of microseconds to wait before trying again or true in case of success.
+     *
+     * @see \HeadlessChromium\Utils::tryWithTimeout
+     *
      * @param int $targetX
      * @param int $targetY
      *

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -74,11 +74,9 @@ class MouseApiTest extends BaseTestCase
     {
         // initial navigation
         $page = $this->openSitePage('bigLayout.html');
-        \usleep(200000);
 
         // scroll 100px down
         $page->mouse()->scrollDown(100);
-        \usleep(200000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
@@ -86,7 +84,6 @@ class MouseApiTest extends BaseTestCase
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
-        \usleep(200000);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 


### PR DESCRIPTION
The `scroll` method will return only when the browser finishes scrolling. Removing the need of using `\usleep` in tests.