### PR TITLE
Change `bellow` to `below`

### DIFF
--- a/examples/persistent-browser.php
+++ b/examples/persistent-browser.php
@@ -28,7 +28,7 @@ if (\file_exists($socketFile)) {
         ]);
     } catch (\HeadlessChromium\Exception\BrowserConnectionFailed $e) {
         // The browser was probably closed
-        // Keep $browser null and start it again bellow
+        // Keep $browser null and start it again below
     }
 }
 


### PR DESCRIPTION
According to https://prowritingaid.com/grammar/1000167/Bellow-vs-below%E2%80%94what-is-the-difference, `bellow` has a different meaning than `below`.