### PR TITLE
Remove command line arguments that prevent login to google

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -293,8 +293,6 @@ class BrowserProcess implements LoggerAwareInterface
             '--disable-background-networking',
             '--disable-background-timer-throttling',
             '--disable-client-side-phishing-detection',
-            '--disable-default-apps',
-            '--disable-extensions',
             '--disable-hang-monitor',
             '--disable-popup-blocking',
             '--disable-prompt-on-repost',


### PR DESCRIPTION
Source of the arguments that must be removed : 
https://github.com/berstend/puppeteer-extra/pull/579

Those arguments which are non used on regular browser can be detected to know you are a bot