### PR TITLE
Rework PagePdf class to improve validations and tests

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -555,6 +555,8 @@ class Page
      *                       - marginBottom: default 1 cm
      *                       - marginLeft: default 1 cm
      *                       - marginRight: default 1 cm
+     *                       - pageRanges: Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages
+     *                       - ignoreInvalidPageRanges: Whether to silently ignore invalid but successfully parsed page ranges, such as '3-2'. Defaults to false
      *                       - preferCSSPageSize: default false
      *                       - scale: default 1
      *

--- a/src/Page.php
+++ b/src/Page.php
@@ -559,6 +559,7 @@ class Page
      *                       - scale: default 1
      *
      * @throws CommunicationException
+     * @throws \InvalidArgumentException
      *
      * @return PagePdf
      */
@@ -566,128 +567,7 @@ class Page
     {
         $this->assertNotClosed();
 
-        $pdfOptions = [];
-
-        // is landscape?
-        if (\array_key_exists('landscape', $options)) {
-            // landscape requires type to be boolean
-            if (!\is_bool($options['landscape'])) {
-                throw new \InvalidArgumentException('Invalid options "landscape" for print to pdf. Must be true or false');
-            }
-            $pdfOptions['landscape'] = $options['landscape'];
-        }
-
-        // should print background?
-        if (\array_key_exists('printBackground', $options)) {
-            // printBackground requires type to be boolean
-            if (!\is_bool($options['printBackground'])) {
-                throw new \InvalidArgumentException('Invalid options "printBackground" for print to pdf. Must be true or false');
-            }
-            $pdfOptions['printBackground'] = $options['printBackground'];
-        }
-
-        // option displayHeaderFooter
-        if (\array_key_exists('displayHeaderFooter', $options)) {
-            // displayHeaderFooter requires type to be boolean
-            if (!\is_bool($options['displayHeaderFooter'])) {
-                throw new \InvalidArgumentException('Invalid options "displayHeaderFooter" for print to pdf. Must be true or false');
-            }
-            $pdfOptions['displayHeaderFooter'] = $options['displayHeaderFooter'];
-        }
-
-        // option headerTemplate
-        if (\array_key_exists('headerTemplate', $options)) {
-            // headerTemplate requires type to be string
-            if (!\is_string($options['headerTemplate'])) {
-                throw new \InvalidArgumentException('Invalid options "headerTemplate" for print to pdf. Must be string');
-            }
-            $pdfOptions['headerTemplate'] = $options['headerTemplate'];
-        }
-
-        // option footerTemplate
-        if (\array_key_exists('footerTemplate', $options)) {
-            // footerTemplate requires type to be string
-            if (!\is_string($options['footerTemplate'])) {
-                throw new \InvalidArgumentException('Invalid options "footerTemplate" for print to pdf. Must be string');
-            }
-            $pdfOptions['footerTemplate'] = $options['footerTemplate'];
-        }
-
-        // option paperWidth
-        if (\array_key_exists('paperWidth', $options)) {
-            // paperWidth requires type to be float
-            if ('double' !== \gettype($options['paperWidth'])) {
-                throw new \InvalidArgumentException('Invalid options "paperWidth" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['paperWidth'] = $options['paperWidth'];
-        }
-
-        // option paperHeight
-        if (\array_key_exists('paperHeight', $options)) {
-            // paperHeight requires type to be float
-            if ('double' !== \gettype($options['paperHeight'])) {
-                throw new \InvalidArgumentException('Invalid options "paperHeight" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['paperHeight'] = $options['paperHeight'];
-        }
-
-        // option marginTop
-        if (\array_key_exists('marginTop', $options)) {
-            // marginTop requires type to be float
-            if ('double' !== \gettype($options['marginTop'])) {
-                throw new \InvalidArgumentException('Invalid options "marginTop" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['marginTop'] = $options['marginTop'];
-        }
-
-        // option marginBottom
-        if (\array_key_exists('marginBottom', $options)) {
-            // marginBottom requires type to be float
-            if ('double' !== \gettype($options['marginBottom'])) {
-                throw new \InvalidArgumentException('Invalid options "marginBottom" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['marginBottom'] = $options['marginBottom'];
-        }
-
-        // option marginLeft
-        if (\array_key_exists('marginLeft', $options)) {
-            // marginLeft requires type to be float
-            if ('double' !== \gettype($options['marginLeft'])) {
-                throw new \InvalidArgumentException('Invalid options "marginLeft" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['marginLeft'] = $options['marginLeft'];
-        }
-
-        // option marginRight
-        if (\array_key_exists('marginRight', $options)) {
-            // marginRight requires type to be float
-            if ('double' !== \gettype($options['marginRight'])) {
-                throw new \InvalidArgumentException('Invalid options "marginRight" for print to pdf. Must be float like 1.0 or 5.4');
-            }
-            $pdfOptions['marginRight'] = $options['marginRight'];
-        }
-
-        // option preferCSSPageSize
-        if (\array_key_exists('preferCSSPageSize', $options)) {
-            // preferCSSPageSize requires type to be boolean
-            if (!\is_bool($options['preferCSSPageSize'])) {
-                throw new \InvalidArgumentException('Invalid options "preferCSSPageSize" for print to pdf. Must be true or false');
-            }
-            $pdfOptions['preferCSSPageSize'] = $options['preferCSSPageSize'];
-        }
-
-        if (\array_key_exists('scale', $options)) {
-            if (!\is_float($options['scale'])) {
-                throw new \InvalidArgumentException('Invalid options "scale" for print to pdf. Must be float like 1.0 or 0.74');
-            }
-            $pdfOptions['scale'] = $options['scale'];
-        }
-
-        // request pdf
-        $responseReader = $this->getSession()
-            ->sendMessage(new Message('Page.printToPDF', $pdfOptions));
-
-        return new PagePdf($responseReader);
+        return new PagePdf($this, $options);
     }
 
     /**

--- a/src/PageUtils/PagePdf.php
+++ b/src/PageUtils/PagePdf.php
@@ -36,7 +36,7 @@ class PagePdf extends AbstractBinaryInput
         'marginBottom' => self::TYPE_NUMERIC,
         'marginLeft' => self::TYPE_NUMERIC,
         'marginRight' => self::TYPE_NUMERIC,
-        'pageRanges'              => self::TYPE_STRING,
+        'pageRanges' => self::TYPE_STRING,
         'ignoreInvalidPageRanges' => self::TYPE_BOOLEAN,
         'preferCSSPageSize' => self::TYPE_BOOLEAN,
         'scale' => self::TYPE_NUMERIC,

--- a/src/PageUtils/PagePdf.php
+++ b/src/PageUtils/PagePdf.php
@@ -11,10 +11,104 @@
 
 namespace HeadlessChromium\PageUtils;
 
+use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Exception\PdfFailed;
+use HeadlessChromium\Page;
 
 class PagePdf extends AbstractBinaryInput
 {
+    private const TYPE_NUMERIC = 1;
+    private const TYPE_STRING = 2;
+    private const TYPE_BOOLEAN = 3;
+
+    /**
+     * @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF
+     */
+    private const OPTIONS = [
+        'landscape' => self::TYPE_BOOLEAN,
+        'printBackground' => self::TYPE_BOOLEAN,
+        'displayHeaderFooter' => self::TYPE_BOOLEAN,
+        'headerTemplate' => self::TYPE_STRING,
+        'footerTemplate' => self::TYPE_STRING,
+        'paperWidth' => self::TYPE_NUMERIC,
+        'paperHeight' => self::TYPE_NUMERIC,
+        'marginTop' => self::TYPE_NUMERIC,
+        'marginBottom' => self::TYPE_NUMERIC,
+        'marginLeft' => self::TYPE_NUMERIC,
+        'marginRight' => self::TYPE_NUMERIC,
+        'pageRanges'              => self::TYPE_STRING,
+        'ignoreInvalidPageRanges' => self::TYPE_BOOLEAN,
+        'preferCSSPageSize' => self::TYPE_BOOLEAN,
+        'scale' => self::TYPE_NUMERIC,
+    ];
+
+    /**
+     * @var Page
+     */
+    private $page;
+
+    private $options = [];
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     */
+    public function __construct(Page $page, array $options = [])
+    {
+        $this->page = $page;
+
+        $this->setOptions($options)->print();
+    }
+
+    /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     */
+    public function print(): self
+    {
+        $responseReader = $this->page->getSession()->sendMessage(new Message('Page.printToPDF', $this->options));
+
+        parent::__construct($responseReader);
+
+        return $this;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function setOptions(array $options): self
+    {
+        \array_map([$this, 'validateOption'], \array_keys($options), $options);
+
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @param string                $name
+     * @param string|int|float|bool $value
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validateOption(string $name, $value): bool
+    {
+        if (false === \in_array($name, \array_keys(self::OPTIONS))) {
+            throw new \InvalidArgumentException("Unknown option '{$name}' for print to pdf.");
+        }
+        switch (self::OPTIONS[$name]) {
+            case self::TYPE_NUMERIC:
+                \is_numeric($value) || $this->invalidArgument("Invalid option '{$name}' for print to pdf. Must be numeric.");
+                break;
+            case self::TYPE_STRING:
+                \is_string($value) || $this->invalidArgument("Invalid option '{$name}' for print to pdf. Must be string.");
+                break;
+            case self::TYPE_BOOLEAN:
+                \is_bool($value) || $this->invalidArgument("Invalid option '{$name}' for print to pdf. Must be boolean.");
+                break;
+        }
+
+        return true;
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -25,5 +119,15 @@ class PagePdf extends AbstractBinaryInput
         return new PdfFailed(
             \sprintf('Cannot make a PDF. Reason : %s', $message)
         );
+    }
+
+    /**
+     * Wrapper to throw exception in expression when running in php 7.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function invalidArgument(string $message): void
+    {
+        throw new \InvalidArgumentException($message);
     }
 }

--- a/tests/PagePdfForTests.php
+++ b/tests/PagePdfForTests.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\PageUtils\PagePdf;
+
+class PagePdfForTests extends PagePdf
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/PagePdfTest.php
+++ b/tests/PagePdfTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\PageUtils\PagePdf;
+
+/**
+ * @covers \HeadlessChromium\PagePdf
+ */
+class PagePdfTest extends BaseTestCase
+{
+    private const TYPES_STRING = [
+        'string',
+        '',
+    ];
+
+    private const TYPES_NUMERIC = [
+        1,
+        1.1,
+    ];
+
+    private const TYPES_BOOLEAN = [
+        true,
+        false,
+    ];
+
+    /**
+     * @var PagePdfForTests
+     */
+    private $pagePdf;
+
+    /**
+     * @before
+     */
+    public function createEmptyPagePdf(): void
+    {
+        $this->pagePdf = new PagePdfForTests();
+    }
+
+    public function invalidPdfOptionsProvider(): array
+    {
+        return \array_merge(
+            $this->getOptionsDataset('landscape', self::TYPES_STRING),
+            $this->getOptionsDataset('headerTemplate', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('scale', self::TYPES_STRING),
+            [['headerTemplate', new \stdClass()]],
+            [['footerTemplate', []]],
+            [['unknown_field',  1]],
+        );
+    }
+
+    public function validPdfOptionsProvider(): array
+    {
+        return \array_merge(
+            $this->getOptionsDataset('landscape', self::TYPES_BOOLEAN),
+            $this->getOptionsDataset('printBackground', self::TYPES_BOOLEAN),
+            $this->getOptionsDataset('displayHeaderFooter', self::TYPES_BOOLEAN),
+            $this->getOptionsDataset('headerTemplate', self::TYPES_STRING),
+            $this->getOptionsDataset('footerTemplate', self::TYPES_STRING),
+            $this->getOptionsDataset('paperWidth', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('paperHeight', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('marginTop', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('marginBottom', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('marginLeft', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('marginRight', self::TYPES_NUMERIC),
+            $this->getOptionsDataset('pageRanges',              self::TYPES_STRING),
+            $this->getOptionsDataset('ignoreInvalidPageRanges', self::TYPES_BOOLEAN),
+            $this->getOptionsDataset('preferCSSPageSize', self::TYPES_BOOLEAN),
+            $this->getOptionsDataset('scale', self::TYPES_NUMERIC),
+        );
+    }
+
+    /**
+     * @dataProvider invalidPdfOptionsProvider
+     */
+    public function testInvalidOptions(string $optionName, $optionValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->pagePdf->setOptions([$optionName => $optionValue]);
+    }
+
+    /**
+     * @dataProvider validPdfOptionsProvider
+     */
+    public function testValidOptions(string $optionName, $optionValue): void
+    {
+        $this->assertInstanceOf(PagePdf::class, $this->pagePdf->setOptions([$optionName => $optionValue]));
+    }
+
+    private function getOptionsDataset(string $optionName, array $optionValues): array
+    {
+        return \array_reduce(
+            $optionValues,
+            function ($carry, $value) use ($optionName) {
+                $carry[] = [$optionName, $value];
+
+                return $carry;
+            },
+            []
+        );
+    }
+}

--- a/tests/PagePdfTest.php
+++ b/tests/PagePdfTest.php
@@ -72,7 +72,7 @@ class PagePdfTest extends BaseTestCase
             $this->getOptionsDataset('marginBottom', self::TYPES_NUMERIC),
             $this->getOptionsDataset('marginLeft', self::TYPES_NUMERIC),
             $this->getOptionsDataset('marginRight', self::TYPES_NUMERIC),
-            $this->getOptionsDataset('pageRanges',              self::TYPES_STRING),
+            $this->getOptionsDataset('pageRanges', self::TYPES_STRING),
             $this->getOptionsDataset('ignoreInvalidPageRanges', self::TYPES_BOOLEAN),
             $this->getOptionsDataset('preferCSSPageSize', self::TYPES_BOOLEAN),
             $this->getOptionsDataset('scale', self::TYPES_NUMERIC),

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -11,6 +11,7 @@
 
 namespace HeadlessChromium\Test;
 
+use finfo;
 use HeadlessChromium\BrowserFactory;
 
 /**
@@ -254,14 +255,22 @@ class PageTest extends BaseTestCase
         $this->assertEquals(1000, $clip->getHeight());
     }
 
-    public function testInvalidScaleOptionThrowAnException(): void
+    public function testPdf(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-
+        $finfo = new finfo(\FILEINFO_MIME_TYPE);
         $factory = new BrowserFactory();
+
         $browser = $factory->createBrowser();
         $page = $browser->createPage();
-        $page->pdf(['scale' => '2px']);
+
+        $page->navigate(self::sitePath('index.html'))->waitForNavigation();
+
+        $pagePdf = $page->pdf(['landscape' => false]);
+
+        $pdf = $pagePdf->getBase64();
+        $mimeType = $finfo->buffer(\base64_decode($pdf));
+
+        $this->assertSame('application/pdf', $mimeType);
     }
 
     public function testGetHtml(): void


### PR DESCRIPTION
- The validations were improved and moved to the `PagePdf::class`, making it easier to add new options to the list.
- `pageRanges` and `ignoreInvalidPageRanges` were added to the options list (in a separate commit).
- Tests were introduced to test both the validations and the pdf creation.

I'm using `is_numeric` to validate numbers that were previously validated as float/double. The doc says they must be a number, not necessarily a float.

Resolves #275 