### PR TITLE
Suppress the depreciation error in PHP 8.1

### DIFF
--- a/src/Communication/Response.php
+++ b/src/Communication/Response.php
@@ -101,6 +101,7 @@ class Response implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return \array_key_exists($offset, $this->data);
@@ -109,6 +110,7 @@ class Response implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset];
@@ -117,6 +119,7 @@ class Response implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new \Exception('Responses are immutable');
@@ -125,6 +128,7 @@ class Response implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new \Exception('Responses are immutable');


### PR DESCRIPTION
To suppress the error for the following files I added ReturnTypeWillChange attributes. The same for the Symfony symfony/symfony#41495

This PR will have a support for PHP8.1