### PR TITLE
Get an Array of Cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 phpstan.neon
 phpunit.xml
 vendor
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 phpstan.neon
 phpunit.xml
 vendor
+.idea

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -16,7 +16,7 @@ class Cookie implements \ArrayAccess
     /**
      * @var array
      */
-    protected $data;
+    private $data;
 
     /**
      * Cookie constructor.
@@ -28,6 +28,14 @@ class Cookie implements \ArrayAccess
         }
 
         $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->data;
     }
 
     /**

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -16,7 +16,7 @@ class Cookie implements \ArrayAccess
     /**
      * @var array
      */
-    protected $data;
+    public $data;
 
     /**
      * Cookie constructor.

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -16,7 +16,7 @@ class Cookie implements \ArrayAccess
     /**
      * @var array
      */
-    private $data;
+    protected $data;
 
     /**
      * Cookie constructor.

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -16,7 +16,7 @@ class Cookie implements \ArrayAccess
     /**
      * @var array
      */
-    public $data;
+    protected $data;
 
     /**
      * Cookie constructor.

--- a/src/Cookies/CookiesCollection.php
+++ b/src/Cookies/CookiesCollection.php
@@ -127,4 +127,63 @@ class CookiesCollection implements \IteratorAggregate, \Countable
 
         return null;
     }
+
+    /**
+     * Get List of all Cookies with Values
+     *
+     * usage:
+     *
+     * $cookie_data = $cookies->getListAsArray();
+     *
+     *
+     * @return array
+     */
+    public function getListAsArray()
+    {
+        $cookie_array = array();
+        foreach ($this->cookies as $cookie) {
+            $cookie_array[]=($cookie->data);
+        }
+        return $cookie_array;
+    }
+
+    /**
+     * Get List of all Cookies with only Names as Values
+     *
+     * usage:
+     *
+     * $cookie_data = $cookies->getListNamesAsArray();
+     *
+     *
+     * @return array
+     */
+    public function getListNamesAsArray():array
+    {
+        $cookie_array = array();
+        foreach ($this->cookies as $cookie) {
+            $cookie_array[] = trim($cookie->data['name']);
+        }
+        return $cookie_array;
+    }
+
+    /**
+     * Get List of all Cookies with all Data as numeric Array
+     *
+     * usage:
+     *
+     * $cookie_data = $cookies->getListAllDataAsArray();
+     *
+     *
+     * @return array
+     */
+    public function getListAllDataAsArray():array
+    {
+        $cookie_array = array();
+        $i = 0;
+        foreach ($this->cookies as $cookie) {
+            $cookie_array[$i]=$cookie->data;
+            $i++;
+        }
+        return $cookie_array;
+    }
 }

--- a/src/Cookies/CookiesCollection.php
+++ b/src/Cookies/CookiesCollection.php
@@ -142,7 +142,7 @@ class CookiesCollection implements \IteratorAggregate, \Countable
     {
         $cookie_array = array();
         foreach ($this->cookies as $cookie) {
-            $cookie_array[] = trim($cookie->data['name']);
+            $cookie_array[] = trim($cookie->getName());
         }
         return $cookie_array;
     }
@@ -160,10 +160,8 @@ class CookiesCollection implements \IteratorAggregate, \Countable
     public function getListAllDataAsArray():array
     {
         $cookie_array = array();
-        $i = 0;
         foreach ($this->cookies as $cookie) {
-            $cookie_array[$i]=$cookie->data;
-            $i++;
+            $cookie_array[] = $cookie->getData();
         }
         return $cookie_array;
     }

--- a/src/Cookies/CookiesCollection.php
+++ b/src/Cookies/CookiesCollection.php
@@ -129,25 +129,6 @@ class CookiesCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Get List of all Cookies with Values
-     *
-     * usage:
-     *
-     * $cookie_data = $cookies->getListAsArray();
-     *
-     *
-     * @return array
-     */
-    public function getListAsArray()
-    {
-        $cookie_array = array();
-        foreach ($this->cookies as $cookie) {
-            $cookie_array[]=($cookie->data);
-        }
-        return $cookie_array;
-    }
-
-    /**
      * Get List of all Cookies with only Names as Values
      *
      * usage:


### PR DESCRIPTION
We added 2 methods to get an Array of used Cookies of a given page and an Array of the names of these Cookies, for this purpose we added a method to get the whole raw data from the Cookie Class.

`$cookies->getListNamesAsArray();`
`$cookies->getListAllDataAsArray();`


This is quite handy if you want to have a Look at the Cookies a page ist using.

Also added .idea for the gitignore - setting files from jetbrains IDEs.
