### PR TITLE
Fixed issues with `Keyboard::typeText` with multibyte strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "monolog/monolog": "^1.26 || ^2.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
+        "symfony/polyfill-mbstring": "^1.23",
         "symfony/process": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev":{

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -56,7 +56,7 @@ class Keyboard
             $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
                 'type' => 'char',
                 'modifiers' => $this->getModifiers(),
-                'text' => mb_substr($text, $i, 1),
+                'text' => \mb_substr($text, $i, 1),
             ]));
 
             \usleep($this->sleep);

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -50,7 +50,7 @@ class Keyboard
     {
         $this->page->assertNotClosed();
 
-        $length = \strlen($text);
+        $length = \mb_strlen($text);
 
         for ($i = 0; $i < $length; ++$i) {
             $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -56,7 +56,7 @@ class Keyboard
             $this->page->getSession()->sendMessageSync(new Message('Input.dispatchKeyEvent', [
                 'type' => 'char',
                 'modifiers' => $this->getModifiers(),
-                'text' => $text[$i],
+                'text' => mb_substr($text, $i, 1),
             ]));
 
             \usleep($this->sleep);

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -170,7 +170,7 @@ class KeyboardApiTest extends BaseTestCase
         $this->assertGreaterThan(300, $millisecondsElapsed);
     }
     
-     /**
+    /**
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\CommunicationException\InvalidResponse

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -169,7 +169,7 @@ class KeyboardApiTest extends BaseTestCase
         // if this test takes less than 300ms to run (3 keys x 100ms), setKeyInterval is not working
         $this->assertGreaterThan(300, $millisecondsElapsed);
     }
-    
+
     /**
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
@@ -180,9 +180,8 @@ class KeyboardApiTest extends BaseTestCase
         // initial navigation
         $page = $this->openSitePage('form.html');
 
-        //Unicode text
         $text = 'Со ГӀалгӀа ва';
-        
+
         $page->keyboard()
             ->type('Tab')
             ->typeText($text);
@@ -192,6 +191,6 @@ class KeyboardApiTest extends BaseTestCase
             ->getReturnValue();
 
         // checks if the input contains the typed text
-        $this->assertEquals($text, $value);
+        $this->assertSame($text, $value);
     }
 }

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -169,4 +169,29 @@ class KeyboardApiTest extends BaseTestCase
         // if this test takes less than 300ms to run (3 keys x 100ms), setKeyInterval is not working
         $this->assertGreaterThan(300, $millisecondsElapsed);
     }
+    
+     /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\CommunicationException\InvalidResponse
+     */
+    public function testTypeUnicodeText(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('form.html');
+
+        //Unicode text
+        $text = 'Со ГӀалгӀа ва';
+        
+        $page->keyboard()
+            ->type('Tab')
+            ->typeText($text);
+
+        $value = $page
+            ->evaluate('document.querySelector("#myinput").value;')
+            ->getReturnValue();
+
+        // checks if the input contains the typed text
+        $this->assertEquals($text, $value);
+    }
 }


### PR DESCRIPTION
Exception HeadlessChromium\Exception\CommunicationException\InvalidResponse throws when you try to type unicode string keyboard()->typeText("Юникод строка")