### PR TITLE
[1.3] Add support for --no-proxy-server and --proxy-bypass-list Chrome args

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Here are the options available for the browser factory:
 | `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                              |
 | `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                   |
 | `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                  |
+| `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.    |
+| `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections       |
 | `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)  |
 | `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                               |
 | `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -362,6 +362,12 @@ class BrowserProcess implements LoggerAwareInterface
         if (\array_key_exists('proxyServer', $options)) {
             $args[] = '--proxy-server='.$options['proxyServer'];
         }
+        if (\array_key_exists('noProxyServer', $options)) {
+            $args[] = '--no-proxy-server';
+        }
+        if (\array_key_exists('proxyBypassList', $options)) {
+            $args[] = '--proxy-bypass-list='.$options['proxyBypassList'];
+        }
 
         // add custom flags
         if (\array_key_exists('customFlags', $options) && \is_array($options['customFlags'])) {

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -362,7 +362,7 @@ class BrowserProcess implements LoggerAwareInterface
         if (\array_key_exists('proxyServer', $options)) {
             $args[] = '--proxy-server='.$options['proxyServer'];
         }
-        if (\array_key_exists('noProxyServer', $options)) {
+        if (\array_key_exists('noProxyServer', $options) && $options['noProxyServer']) {
             $args[] = '--no-proxy-server';
         }
         if (\array_key_exists('proxyBypassList', $options)) {


### PR DESCRIPTION
Adds support for two more proxy related flags with Chrome.  Suggestions on various issues across repos indicate this helps reduce navigation time.

https://peter.sh/experiments/chromium-command-line-switches/#no-proxy-server
https://peter.sh/experiments/chromium-command-line-switches/#proxy-bypass-list
https://www.chromium.org/developers/design-documents/network-settings
https://github.com/codeceptjs/CodeceptJS/issues/561#issuecomment-373666779