### PR TITLE
[1.3] Replace microtime with hrtime

### DIFF
--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -212,7 +212,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     private function waitForDelay(): void
     {
         if ($this->lastMessageSentTime) {
-            $currentTime = (int) (\microtime(true) * 1000);
+            $currentTime = (int) (\hrtime(true) / 1000 / 1000);
             // if not enough time was spent until last message was sent, wait
             if ($this->lastMessageSentTime + $this->delay > $currentTime) {
                 $timeToWait = ($this->lastMessageSentTime + $this->delay) - $currentTime;
@@ -220,7 +220,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
             }
         }
 
-        $this->lastMessageSentTime = (int) (\microtime(true) * 1000);
+        $this->lastMessageSentTime = (int) (\hrtime(true) / 1000 / 1000);
     }
 
     /**

--- a/src/Exception/OperationTimedOut.php
+++ b/src/Exception/OperationTimedOut.php
@@ -15,18 +15,19 @@ class OperationTimedOut extends \Exception
 {
     public static function createFromTimeout(int $timeoutMicroSec): self
     {
-        return new self('Operation timed out ('.self::getTimeoutPhrase($timeoutMicroSec).')');
+        return new self(sprintf('Operation timed out after %s.'), self::getTimeoutPhrase($timeoutMicroSec));
     }
 
     private static function getTimeoutPhrase(int $timeoutMicroSec): string
     {
         if ($timeoutMicroSec > 1000 * 1000) {
-            return (int) ($timeoutMicroSec / (1000 * 1000)).'sec';
-        }
-        if ($timeoutMicroSec > 1000) {
-            return (int) ($timeoutMicroSec / 1000).'ms';
+            return sprintf('%ds', (int) ($timeoutMicroSec / (1000 * 1000)));
         }
 
-        return (int) ($timeoutMicroSec).'μs';
+        if ($timeoutMicroSec > 1000) {
+            return sprintf('%dms', (int) ($timeoutMicroSec / 1000));
+        }
+
+        return sprintf('%dμs', (int) ($timeoutMicroSec));
     }
 }

--- a/src/Exception/OperationTimedOut.php
+++ b/src/Exception/OperationTimedOut.php
@@ -15,7 +15,7 @@ class OperationTimedOut extends \Exception
 {
     public static function createFromTimeout(int $timeoutMicroSec): self
     {
-        return new self(sprintf('Operation timed out after %s.'), self::getTimeoutPhrase($timeoutMicroSec));
+        return new self(sprintf('Operation timed out after %s.', self::getTimeoutPhrase($timeoutMicroSec)));
     }
 
     private static function getTimeoutPhrase(int $timeoutMicroSec): string

--- a/src/Exception/OperationTimedOut.php
+++ b/src/Exception/OperationTimedOut.php
@@ -13,4 +13,20 @@ namespace HeadlessChromium\Exception;
 
 class OperationTimedOut extends \Exception
 {
+    public static function createFromTimeout(int $timeoutMicroSec): self
+    {
+        return new self('Operation timed out ('.self::getTimeoutPhrase($timeoutMicroSec).')');
+    }
+
+    private static function getTimeoutPhrase(int $timeoutMicroSec): string
+    {
+        if ($timeoutMicroSec > 1000 * 1000) {
+            return (int) ($timeoutMicroSec / (1000 * 1000)).'sec';
+        }
+        if ($timeoutMicroSec > 1000) {
+            return (int) ($timeoutMicroSec / 1000).'ms';
+        }
+
+        return (int) ($timeoutMicroSec).'μs';
+    }
 }

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -157,14 +157,14 @@ class KeyboardApiTest extends BaseTestCase
         // initial navigation
         $page = $this->openSitePage('form.html');
 
-        $start = \round(\microtime(true) * 1000);
+        $start = \round(\hrtime(true) / 1000 / 1000);
 
         $page->keyboard()
             ->setKeyInterval(100)
             ->typeRawKey('Tab')
             ->typeText('bar');
 
-        $millisecondsElapsed = \round(\microtime(true) * 1000) - $start;
+        $millisecondsElapsed = \round(\hrtime(true) / 1000 / 1000) - $start;
 
         // if this test takes less than 300ms to run (3 keys x 100ms), setKeyInterval is not working
         $this->assertGreaterThan(300, $millisecondsElapsed);


### PR DESCRIPTION
The system clock shouldn't interfere with the calculation of timeouts.

This PR needs to be reviewed with some care since there are no tests for the timeouts themselves.