### PR TITLE
[1.3] Fix `Mouse::find()` after cursor has moved

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -285,14 +285,16 @@ class Mouse
         $rightBoundary = \floor($element['right']);
         $bottomBoundary = \floor($element['bottom']);
 
-        $positionX = \mt_rand(\ceil($element['left']), $rightBoundary);
-        $positionY = \mt_rand(\ceil($element['top']), $bottomBoundary);
+        $this->scrollToBoundary($rightBoundary, $bottomBoundary);
 
-        $this->scrollToBoundary($rightBoundary, $bottomBoundary)
-            ->move(
-                ($positionX - $this->x),
-                ($positionY - $this->y)
-            );
+        $visibleArea = $this->page->getLayoutMetrics()->getLayoutViewport();
+
+        $offsetX = $visibleArea['pageX'];
+        $offsetY = $visibleArea['pageY'];
+        $positionX = \mt_rand(\ceil($element['left'] - $offsetX), $rightBoundary - $offsetX);
+        $positionY = \mt_rand(\ceil($element['top'] - $offsetY), $bottomBoundary - $offsetY);
+
+        $this->move($positionX, $positionY);
 
         return $this;
     }

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -291,8 +291,8 @@ class Mouse
 
         $offsetX = $visibleArea['pageX'];
         $offsetY = $visibleArea['pageY'];
-        $positionX = \mt_rand(\ceil($element['left'] - $offsetX), $rightBoundary - $offsetX);
-        $positionY = \mt_rand(\ceil($element['top'] - $offsetY), $bottomBoundary - $offsetY);
+        $positionX = \random_int(\ceil($element['left'] - $offsetX), $rightBoundary - $offsetX);
+        $positionY = \random_int(\ceil($element['top'] - $offsetY), $bottomBoundary - $offsetY);
 
         $this->move($positionX, $positionY);
 

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -118,6 +118,25 @@ class MouseApiTest extends BaseTestCase
     }
 
     /**
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     */
+    public function testFind_afterMove(): void
+    {
+        // initial navigation
+        $page = $this->openSitePage('b.html');
+
+        $page->mouse()->move(1000, 1000);
+
+        $page->mouse()->find('#a')->click();
+        $page->waitForReload();
+
+        $title = $page->evaluate('document.title')->getReturnValue();
+
+        $this->assertEquals('a - test', $title);
+    }
+
+    /**
      * @dataProvider mouseFindProvider
      *
      * @throws \HeadlessChromium\Exception\CommunicationException


### PR DESCRIPTION
After scrolling to the element, its boundaries change and we have to read the viewport offsets in order to compute final coordinates.