### PR TITLE
[1.3] Drop "go to a" from bigLayout as it might accidentally make tests testing big layouts succeed in redirecting

### DIFF
--- a/tests/resources/static-web/bigLayout.html
+++ b/tests/resources/static-web/bigLayout.html
@@ -12,8 +12,6 @@
 <h1>page b</h1>
 <div>b</div>
 
-<a id="a" href="./a.html">go to a</a>
-
 <div style="float:right;margin-top:100%">
     <a id="bottomLink" href="./a.html">go to a</a>
 </div>


### PR DESCRIPTION
(this is not happening anywhere AFAIK *yet*)