### PR TITLE
[1.3] Make it work with retina

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -178,11 +178,11 @@ class Mouse
     {
         $this->page->assertNotClosed();
 
-        $scollableArea = $this->page->getLayoutMetrics()->getContentSize();
-        $visibleArea = $this->page->getLayoutMetrics()->getVisualViewport();
+        $scrollableArea = $this->page->getLayoutMetrics()->getCssContentSize();
+        $visibleArea = $this->page->getLayoutMetrics()->getCssVisualViewport();
 
-        $distanceX = $this->getMaximumDistance($distanceX, $visibleArea['pageX'], $scollableArea['width']);
-        $distanceY = $this->getMaximumDistance($distanceY, $visibleArea['pageY'], $scollableArea['height']);
+        $distanceX = $this->getMaximumDistance($distanceX, $visibleArea['pageX'], $scrollableArea['width']);
+        $distanceY = $this->getMaximumDistance($distanceY, $visibleArea['pageY'], $scrollableArea['height']);
 
         $targetX = $visibleArea['pageX'] + $distanceX;
         $targetY = $visibleArea['pageY'] + $distanceY;
@@ -222,7 +222,7 @@ class Mouse
      */
     private function scrollToBoundary(int $right, int $bottom): self
     {
-        $visibleArea = $this->page->getLayoutMetrics()->getLayoutViewport();
+        $visibleArea = $this->page->getLayoutMetrics()->getCssLayoutViewport();
 
         $distanceX = $distanceY = 0;
 
@@ -338,7 +338,7 @@ class Mouse
     private function waitForScroll(int $targetX, int $targetY)
     {
         while (true) {
-            $visibleArea = $this->page->getLayoutMetrics()->getVisualViewport();
+            $visibleArea = $this->page->getLayoutMetrics()->getCssVisualViewport();
 
             if ($visibleArea['pageX'] === $targetX && $visibleArea['pageY'] === $targetY) {
                 return true;

--- a/src/Page.php
+++ b/src/Page.php
@@ -461,7 +461,7 @@ class Page
      */
     public function getFullPageClip(int $timeout = null): Clip
     {
-        $contentSize = $this->getLayoutMetrics()->await($timeout)->getContentSize();
+        $contentSize = $this->getLayoutMetrics()->await($timeout)->getCssContentSize();
 
         return new Clip(0, 0, $contentSize['width'], $contentSize['height']);
     }

--- a/src/PageUtils/PageLayoutMetrics.php
+++ b/src/PageUtils/PageLayoutMetrics.php
@@ -47,9 +47,7 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getContentSize(): array
     {
-        $response = $this->awaitResponse();
-
-        return $response->getResultData('contentSize');
+        return $this->getResultData('contentSize');
     }
 
     /**
@@ -63,9 +61,7 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getLayoutViewport(): array
     {
-        $response = $this->awaitResponse();
-
-        return $response->getResultData('layoutViewport');
+        return $this->getResultData('layoutViewport');
     }
 
     /**
@@ -79,8 +75,54 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getVisualViewport()
     {
-        $response = $this->awaitResponse();
+        return $this->getResultData('visualViewport');
+    }
 
-        return $response->getResultData('visualViewport');
+    /**
+     * Returns real size of scrollable area.
+     *
+     * @throws CommunicationException\ResponseHasError
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     *
+     * @return array
+     */
+    public function getCssContentSize(): array
+    {
+        return $this->getResultData('cssContentSize');
+    }
+
+    /**
+     * Returns real metrics relating to the layout viewport.
+     *
+     * @throws CommunicationException\ResponseHasError
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     *
+     * @return array
+     */
+    public function getCssLayoutViewport(): array
+    {
+        return $this->getResultData('cssLayoutViewport');
+    }
+
+    /**
+     * Returns real metrics relating to the visual viewport.
+     *
+     * @throws CommunicationException\ResponseHasError
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     *
+     * @return array
+     */
+    public function getCssVisualViewport()
+    {
+        return $this->getResultData('cssVisualViewport');
+    }
+
+    /** @param 'layoutViewport'|'visualViewport'|'contentSize'|'cssLayoutViewport'|'cssVisualViewport'|'cssContentSize' $key */
+    private function getResultData(string $key): array
+    {
+        return $this->awaitResponse()->getResultData($key);
     }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -263,6 +263,9 @@ class PageTest extends BaseTestCase
         $contentSize = $metrics->getContentSize();
         $layoutViewport = $metrics->getLayoutViewport();
         $visualViewport = $metrics->getVisualViewport();
+        $cssContentSize = $metrics->getCssContentSize();
+        $cssLayoutViewport = $metrics->getCssLayoutViewport();
+        $cssVisualViewport = $metrics->getCssVisualViewport();
 
         $this->assertEquals(
             [
@@ -296,6 +299,70 @@ class PageTest extends BaseTestCase
                 'zoom' => 1,
             ],
             $visualViewport
+        );
+
+        // This is made to be a bit loose to pass on retina displays
+
+        $this->assertContains(
+            $cssContentSize,
+            [
+                [
+                    'x' => 0,
+                    'y' => 0,
+                    'width' => 900,
+                    'height' => 1000,
+                ],
+                [
+                    'x' => 0,
+                    'y' => 0,
+                    'width' => 1800,
+                    'height' => 2000,
+                ],
+            ]
+        );
+
+        $this->assertContains(
+            $cssLayoutViewport,
+            [
+                [
+                    'pageX' => 0,
+                    'pageY' => 0,
+                    'clientWidth' => 100,
+                    'clientHeight' => 300,
+                ],
+                [
+                    'pageX' => 0,
+                    'pageY' => 0,
+                    'clientWidth' => 200,
+                    'clientHeight' => 600,
+                ],
+            ]
+        );
+
+        $this->assertContains(
+            $cssVisualViewport,
+            [
+                [
+                    'offsetX' => 0,
+                    'offsetY' => 0,
+                    'pageX' => 0,
+                    'pageY' => 0,
+                    'clientWidth' => 100,
+                    'clientHeight' => 300,
+                    'scale' => 1,
+                    'zoom' => 1,
+                ],
+                [
+                    'offsetX' => 0,
+                    'offsetY' => 0,
+                    'pageX' => 0,
+                    'pageY' => 0,
+                    'clientWidth' => 200,
+                    'clientHeight' => 600,
+                    'scale' => 1,
+                    'zoom' => 1,
+                ],
+            ]
         );
     }
 


### PR DESCRIPTION
I have added a way to read css metrics that are the same as standard ones except that they consider retina displays.

Now the lib works in headful mode on retina displays.