### PR TITLE
[1.4] Prevent `Node::querySelector` from returning nodeId 0

### DIFF
--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -64,7 +64,7 @@ class Node
 
         $nodeId = $response->getResultData('nodeId');
 
-        if (null !== $nodeId) {
+        if (null !== $nodeId && 0 !== $nodeId) {
             return new self($this->page, $nodeId);
         }
 

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -40,8 +40,10 @@ class DomTest extends BaseTestCase
     {
         $page = $this->openSitePage('domForm.html');
         $element = $page->dom()->querySelector('button');
+        $notFoundElement = $page->dom()->querySelector('img');
 
         $this->assertNotNull($element);
+        $this->assertNull($notFoundElement);
     }
 
     public function testSearchByCssSelectorAll(): void
@@ -51,6 +53,9 @@ class DomTest extends BaseTestCase
         $elements = $page->dom()->querySelectorAll('div');
 
         $this->assertCount(2, $elements);
+
+        $notFoundElements = $page->dom()->querySelectorAll('img');
+        $this->assertCount(0, $notFoundElements);
     }
 
     public function testSearchByXpath(): void


### PR DESCRIPTION
Fixes bug with zero node id.