### PR TITLE
[1.5] Add `waitUntilContainsElement()` to Page

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -264,16 +264,7 @@ class Mouse
         $this->page->assertNotClosed();
 
         try {
-            $elementList = $this->page
-                ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")));')
-                ->getReturnValue();
-
-            $position = \max(0, ($position - 1));
-            $position = \min($position, (\count($elementList) - 1));
-
-            $element = $this->page
-                ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")['.$position.'].getBoundingClientRect()));')
-                ->getReturnValue();
+            $element = Utils::getElementPositionFromPage($this->page, $selectors, $position);
         } catch (JavascriptException $exception) {
             throw new ElementNotFoundException('The search for "'.$selectors.'" returned no elements.');
         }

--- a/src/Page.php
+++ b/src/Page.php
@@ -472,16 +472,7 @@ class Page
         while (true) {
 
             try {
-                $elementList = $this
-                    ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")));')
-                    ->getReturnValue();
-
-                $position = \max(0, ($position - 1));
-                $position = \min($position, (\count($elementList) - 1));
-
-                $element = $this
-                    ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")['.$position.'].getBoundingClientRect()));')
-                    ->getReturnValue();
+                $element = Utils::getElementPositionFromPage($this, $selectors, $position);
             } catch (\Throwable $exception) {
                 yield $delay;
             }

--- a/src/Page.php
+++ b/src/Page.php
@@ -19,6 +19,7 @@ use HeadlessChromium\Cookies\CookiesCollection;
 use HeadlessChromium\Dom\Dom;
 use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\InvalidTimezoneId;
+use HeadlessChromium\Exception\JavascriptException;
 use HeadlessChromium\Exception\NoResponseAvailable;
 use HeadlessChromium\Exception\TargetDestroyed;
 use HeadlessChromium\Input\Keyboard;
@@ -470,7 +471,7 @@ class Page
         while (true) {
             try {
                 $element = Utils::getElementPositionFromPage($this, $selectors, $position);
-            } catch (\Throwable $exception) {
+            } catch (JavascriptException $exception) {
                 yield $delay;
             }
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -450,7 +450,7 @@ class Page
      *
      * @return $this
      */
-    public function waitUntilContains(string $selectors, int $timeout = 60000)
+    public function waitUntilContainsElement(string $selectors, int $timeout = 30000)
     {
         $this->assertNotClosed();
 
@@ -460,7 +460,6 @@ class Page
     }
 
     /**
-     *
      * @return bool|\Generator
      *
      * @internal

--- a/src/Page.php
+++ b/src/Page.php
@@ -470,7 +470,6 @@ class Page
         $element = [];
 
         while (true) {
-
             try {
                 $element = Utils::getElementPositionFromPage($this, $selectors, $position);
             } catch (\Throwable $exception) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -447,10 +447,8 @@ class Page
      * @param int    $timeout
      *
      * @throws Exception\OperationTimedOut
-     *
-     * @return $this
      */
-    public function waitUntilContainsElement(string $selectors, int $timeout = 30000)
+    public function waitUntilContainsElement(string $selectors, int $timeout = 30000) : self
     {
         $this->assertNotClosed();
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -449,7 +449,7 @@ class Page
      *
      * @throws Exception\OperationTimedOut
      */
-    public function waitUntilContainsElement(string $selectors, int $timeout = 30000) : self
+    public function waitUntilContainsElement(string $selectors, int $timeout = 30000): self
     {
         $this->assertNotClosed();
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -93,10 +93,10 @@ class Utils
     }
 
     /**
-     * @return mixed|null
-     *
      * @throws CommunicationException
      * @throws Exception\EvaluationFailed
+     *
+     * @return mixed|null
      */
     public static function getElementPositionFromPage(Page $page, string $selectors, int $position = 1)
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -96,7 +96,7 @@ class Utils
      * @throws CommunicationException
      * @throws Exception\EvaluationFailed
      *
-     * @return mixed|null
+     * @return mixed
      */
     public static function getElementPositionFromPage(Page $page, string $selectors, int $position = 1)
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,6 +13,7 @@ namespace HeadlessChromium;
 
 use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Communication\Message;
+use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\OperationTimedOut;
 
 class Utils
@@ -89,5 +90,25 @@ class Utils
                 }
             }
         }
+    }
+
+    /**
+     * @return mixed|null
+     *
+     * @throws CommunicationException
+     * @throws Exception\EvaluationFailed
+     */
+    public static function getElementPositionFromPage(Page $page, string $selectors, int $position = 1)
+    {
+        $elementList = $page
+            ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")));')
+            ->getReturnValue();
+
+        $position = \max(0, ($position - 1));
+        $position = \min($position, (\count($elementList) - 1));
+
+        return $page
+            ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")['.$position.'].getBoundingClientRect()));')
+            ->getReturnValue();
     }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -415,7 +415,7 @@ class PageTest extends BaseTestCase
         $this->assertStringContainsString('<h1>bar</h1>', $page->getHtml());
     }
 
-    public function testWaitUntilContains():void
+    public function testWaitUntilContainsElement():void
     {
         $factory = new BrowserFactory();
 
@@ -424,7 +424,7 @@ class PageTest extends BaseTestCase
 
         $page->navigate(self::sitePath('elementLoad.html'))->waitForNavigation();
 
-        $page->waitUntilContains('div[data-name=\"el\"]');
+        $page->waitUntilContainsElement('div[data-name=\"el\"]');
 
         $this->assertStringContainsString('<div data-name="el"></div>', $page->getHtml());
     }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -414,4 +414,18 @@ class PageTest extends BaseTestCase
 
         $this->assertStringContainsString('<h1>bar</h1>', $page->getHtml());
     }
+
+    public function testWaitUntilContains():void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate(self::sitePath('elementLoad.html'))->waitForNavigation();
+
+        $page->waitUntilContains('div[data-name=\"el\"]');
+
+        $this->assertStringContainsString('<div data-name="el"></div>', $page->getHtml());
+    }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -415,7 +415,7 @@ class PageTest extends BaseTestCase
         $this->assertStringContainsString('<h1>bar</h1>', $page->getHtml());
     }
 
-    public function testWaitUntilContainsElement():void
+    public function testWaitUntilContainsElement(): void
     {
         $factory = new BrowserFactory();
 

--- a/tests/resources/static-web/elementLoad.html
+++ b/tests/resources/static-web/elementLoad.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+    <title>a - test</title>
+</head>
+<body>
+<h1>page a</h1>
+<div>a</div>
+</body>
+<script>
+    setTimeout(() => {
+      let el = document.createElement('div');
+
+      el.dataset.name = 'el';
+
+      document.body.appendChild(el)
+    }, 500)
+</script>
+</html>


### PR DESCRIPTION
Hello, Ive been working with the chrome lib for the past week in our project and I was unable to crawl through a js enhanced website forms without the ability to trigger some delay programmatically, unless including a long delay via `connectionDelay` option.

So I've used some parts of resolving the element in find methods and passed it through the timeout utility to wait for the element to appear with `waitUntilContainsElement`, hoping we could merge this into the main repo or would you choose a different approach?

Thx!