### PR TITLE
[1.4] Add fallback to css layout metrics

### DIFF
--- a/src/PageUtils/PageLayoutMetrics.php
+++ b/src/PageUtils/PageLayoutMetrics.php
@@ -89,7 +89,7 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getCssContentSize(): array
     {
-        return $this->getResultData('cssContentSize');
+        return $this->getResultData('cssContentSize') ?? $this->getContentSize();
     }
 
     /**
@@ -103,7 +103,7 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getCssLayoutViewport(): array
     {
-        return $this->getResultData('cssLayoutViewport');
+        return $this->getResultData('cssLayoutViewport') ?? $this->getLayoutViewport();
     }
 
     /**
@@ -117,7 +117,7 @@ class PageLayoutMetrics extends ResponseWaiter
      */
     public function getCssVisualViewport()
     {
-        return $this->getResultData('cssVisualViewport');
+        return $this->getResultData('cssVisualViewport') ?? $this->getVisualViewport();
     }
 
     /** @param 'layoutViewport'|'visualViewport'|'contentSize'|'cssLayoutViewport'|'cssVisualViewport'|'cssContentSize' $key */


### PR DESCRIPTION
According to https://vanilla.aslushnikov.com/?Page.getLayoutMetrics "no-css" props are deprecated.

However, old versions of chrome might miss them.

Therefore, I'm adding fallback so it does not break old clients.

@p4vel discovered this on `Chromium 90.0.4430.212 built on Debian 10.9, running on Debian 10.11`

![image](https://user-images.githubusercontent.com/327717/151000101-44e45816-8b8a-493e-8d9f-217df04e68c9.png)
