### PR TITLE
[1.4] Fix missing destroyed

### DIFF
--- a/src/Communication/Session.php
+++ b/src/Communication/Session.php
@@ -135,7 +135,7 @@ class Session extends EventEmitter
         }
         $this->emit('destroyed');
         $this->connection = null;
-        $this->removeAllListeners();
         $this->destroyed = true;
+        $this->removeAllListeners();
     }
 }

--- a/src/Communication/Session.php
+++ b/src/Communication/Session.php
@@ -136,5 +136,6 @@ class Session extends EventEmitter
         $this->emit('destroyed');
         $this->connection = null;
         $this->removeAllListeners();
+        $this->destroyed = true;
     }
 }


### PR DESCRIPTION
Without it, it can cause
```
Call to a member function sendMessage() on null in .../Communication/Session.php:68
```

because
```php
$this->getConnection()->sendMessage
```

when it's already destroyed, destroyed is never set and then
getConnection() return null