### PR TITLE
[1.5] Add support for XPath by introducing `Selector` and `Mouse::findElement()`

### DIFF
--- a/src/Dom/Selector/CssSelector.php
+++ b/src/Dom/Selector/CssSelector.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HeadlessChromium\Dom\Selector;
+
+/**
+ * @see https://developer.mozilla.org/docs/Web/API/Document/querySelector
+ */
+final class CssSelector implements Selector
+{
+    /** @var string */
+    private $expression;
+
+    public function __construct(string $expression)
+    {
+        $this->expression = $expression;
+    }
+
+    public function expressionCount(): string
+    {
+        return \sprintf('document.querySelectorAll("%s").length', $this->expression);
+    }
+
+    public function expressionFindOne(int $position): string
+    {
+        return \sprintf('document.querySelectorAll("%s")[%d]', $this->expression, $position - 1);
+    }
+}

--- a/src/Dom/Selector/Selector.php
+++ b/src/Dom/Selector/Selector.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HeadlessChromium\Dom\Selector;
+
+interface Selector
+{
+    public function expressionCount(): string;
+
+    public function expressionFindOne(int $position): string;
+}

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HeadlessChromium\Dom\Selector;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript
+ */
+final class XPathSelector implements Selector
+{
+    /** @var string */
+    private $expression;
+
+    public function __construct(string $expression)
+    {
+        $this->expression = $expression;
+    }
+
+    public function expressionCount(): string
+    {
+        return \sprintf(
+            'document.evaluate("%s", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength',
+            \addslashes($this->expression)
+        );
+    }
+
+    public function expressionFindOne(int $position): string
+    {
+        return \sprintf(
+            'document.evaluate("%s[%d]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue',
+            \addslashes($this->expression),
+            $position
+        );
+    }
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -17,6 +17,7 @@ use HeadlessChromium\Communication\Target;
 use HeadlessChromium\Cookies\Cookie;
 use HeadlessChromium\Cookies\CookiesCollection;
 use HeadlessChromium\Dom\Dom;
+use HeadlessChromium\Dom\Selector\CssSelector;
 use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\InvalidTimezoneId;
 use HeadlessChromium\Exception\JavascriptException;
@@ -444,9 +445,6 @@ class Page
     /**
      * Wait until page contains Node.
      *
-     * @param string $selectors
-     * @param int    $timeout
-     *
      * @throws Exception\OperationTimedOut
      */
     public function waitUntilContainsElement(string $selectors, int $timeout = 30000): self
@@ -470,7 +468,7 @@ class Page
 
         while (true) {
             try {
-                $element = Utils::getElementPositionFromPage($this, $selectors, $position);
+                $element = Utils::getElementPositionFromPage($this, new CssSelector($selectors), $position);
             } catch (JavascriptException $exception) {
                 yield $delay;
             }

--- a/src/PageUtils/PageEvaluation.php
+++ b/src/PageUtils/PageEvaluation.php
@@ -98,6 +98,7 @@ class PageEvaluation
      * @param int|null $timeout
      *
      * @throws EvaluationFailed
+     * @throws JavascriptException
      *
      * @return mixed
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,7 +13,9 @@ namespace HeadlessChromium;
 
 use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Communication\Message;
+use HeadlessChromium\Dom\Selector\Selector;
 use HeadlessChromium\Exception\CommunicationException;
+use HeadlessChromium\Exception\JavascriptException;
 use HeadlessChromium\Exception\OperationTimedOut;
 
 class Utils
@@ -95,20 +97,21 @@ class Utils
     /**
      * @throws CommunicationException
      * @throws Exception\EvaluationFailed
+     * @throws JavascriptException
      *
      * @return mixed
      */
-    public static function getElementPositionFromPage(Page $page, string $selectors, int $position = 1)
+    public static function getElementPositionFromPage(Page $page, Selector $selector, int $position = 1)
     {
-        $elementList = $page
-            ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")));')
+        $elementCount = $page
+            ->evaluate(\sprintf('JSON.parse(JSON.stringify(%s));', $selector->expressionCount()))
             ->getReturnValue();
 
-        $position = \max(0, ($position - 1));
-        $position = \min($position, (\count($elementList) - 1));
+        $position = \max(1, $position);
+        $position = \min($position, $elementCount);
 
         return $page
-            ->evaluate('JSON.parse(JSON.stringify(document.querySelectorAll("'.$selectors.'")['.$position.'].getBoundingClientRect()));')
+            ->evaluate(\sprintf('JSON.parse(JSON.stringify(%s.getBoundingClientRect()));', $selector->expressionFindOne($position)))
             ->getReturnValue();
     }
 }


### PR DESCRIPTION
Resolves https://github.com/chrome-php/chrome/issues/333