### PR TITLE
[1.5] Fix cookie expiration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ $page = $browser->createPage();
 $page->setCookies([
     Cookie::create('name', 'value', [
         'domain' => 'example.com',
-        'expires' => time() + 3600 // expires in 1 day
+        'expires' => time() + 3600 // expires in 1 hour
     ])
 ])->await();
 


### PR DESCRIPTION
Fix the given example for the cookie expiration time as `time() + 3600` refers to the time in one hour rather than in one day from now