### PR TITLE
[1.4] Fix do not open "What's new" page on startup launch

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -303,6 +303,7 @@ class BrowserProcess implements LoggerAwareInterface
             '--disable-prompt-on-repost',
             '--disable-sync',
             '--disable-translate',
+            '--disable-features=ChromeWhatsNewUI',
             '--metrics-recording-only',
             '--no-first-run',
             '--safebrowsing-disable-auto-update',


### PR DESCRIPTION
This is a simple startup argument to avoid openning a "What's new" page on each launch