### PR TITLE
[1.4] Change `uploadFile()` to `sendFile()` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ $elem->sendKeys('Sample text');
 You can upload file to file from the input:
 
 ```php
-$elem->uploadFile('/path/to/file');
+$elem->sendFile('/path/to/file');
 ```
 
 You can get element text or attribute:


### PR DESCRIPTION
Current upload file example is:
`$elem->uploadFile('/path/to/file');`
while it should be:
`$elem->sendFile('/path/to/file');`