### PR TITLE
[1.4] Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ header('Pragma: public');
 echo base64_decode($pdf->getBase64());
 ```
 
-Options `headerTempalte` and `footerTempalte`:
+Options `headerTemplate` and `footerTemplate`:
 
 Should be valid HTML markup with the following classes used to inject printing values into them:
 - date: formatted print date


### PR DESCRIPTION
Hi guys,

just tried chrome-php today and found a typo while reading the doc: `tempalte` instead of `template` so here's my modest contribution!