### PR TITLE
Setting Extra HTTP Headers Not Working

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -82,10 +82,6 @@ class Browser
 
         // enable target discovery
         $connection->sendMessageSync(new Message('Target.setDiscoverTargets', ['discover' => true]));
-
-        // set up http headers
-        $headers = $connection->getConnectionHttpHeaders();
-        $connection->sendMessageSync(new Message('Network.setExtraHTTPHeaders', $headers));
     }
 
     /**

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -150,11 +150,6 @@ class BrowserProcess implements LoggerAwareInterface
             $connection->setConnectionDelay($options['connectionDelay']);
         }
 
-        // connection headers
-        if (\array_key_exists('headers', $options)) {
-            $connection->setConnectionHttpHeaders($options['headers']);
-        }
-
         // set connection to allow killing chrome
         $this->connection = $connection;
 

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -133,24 +133,6 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     }
 
     /**
-     * @param array<string, string> $headers
-     *
-     * @return void
-     */
-    public function setConnectionHttpHeaders(array $headers): void
-    {
-        $this->httpHeaders = $headers;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getConnectionHttpHeaders(): array
-    {
-        return $this->httpHeaders;
-    }
-
-    /**
      * Gets the default timeout used when sending a message synchronously.
      *
      * @return int

--- a/src/Page.php
+++ b/src/Page.php
@@ -181,7 +181,7 @@ class Page
     {
         $this->getSession()->sendMessage(new Message(
             'Network.setExtraHTTPHeaders',
-            $headers
+            ['headers' => $headers]
         ));
     }
 

--- a/tests/Communication/ConnectionTest.php
+++ b/tests/Communication/ConnectionTest.php
@@ -132,19 +132,6 @@ class ConnectionTest extends TestCase
         );
     }
 
-    public function testConnectionHttpHeaders(): void
-    {
-        $connection = new Connection($this->mocSocket);
-
-        $header = [
-            'header_name' => 'header_value',
-        ];
-
-        $connection->setConnectionHttpHeaders($header);
-
-        $this->assertSame($header, $connection->getConnectionHttpHeaders());
-    }
-
     public function testSendMessageSync(): void
     {
         $connection = new Connection($this->mocSocket);


### PR DESCRIPTION
## Issue confirmed and tested only with Google Chrome
Adding option `headers` to the constructor is returning an error in the log `{"code":-32601,"message":"'Network.setExtraHTTPHeaders' wasn't found"}`.
When calling `setEtrxaHTTPHeaders` on the page, the method is accepted but it complains that the format is incorrect `Failed to deserialize params.headers`
It looks like Chrome API expects the headers array to be nested one level deeper under key `headers`.