### PR TITLE
[1.6] Added missing import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ When using ``$navigation->waitForNavigation()`` you will wait for 30sec until th
 You can change the timeout or the event to listen for:
 
 ```php
+use HeadlessChromium\Page;
+
 // wait 10secs for the event "DOMContentLoaded" to be triggered
 $navigation->waitForNavigation(Page::DOM_CONTENT_LOADED, 10000);
 ```


### PR DESCRIPTION
previously it wasn't obvious how to obtain Page::LOAD & co constants

- several ways to do it, one can do, "use HeadlessChromium\Page;" or "$navigation::LOAD" or "\HeadlessChromium\Page::LOAD",  i just picked the one that feels most consistent with the rest of the README.