### PR TITLE
[1.8] Add enum-like class `BrowserOptions` with all options for the browser creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ The following example disables headless mode to ease debugging
 
 ```php
 use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Browser\BrowserOptions;
 
 $browserFactory = new BrowserFactory();
 
 $browser = $browserFactory->createBrowser([
-    'headless' => false, // disable headless mode
+    BrowserOptions::headless => false, // disable headless mode
 ]);
 ```
 
@@ -102,8 +103,8 @@ Other debug options:
 
 ```php
 [
-    'connectionDelay' => 0.8,            // add 0.8 second of delay between each instruction sent to chrome,
-    'debugLogger'     => 'php://stdout', // will enable verbose mode
+    BrowserOptions::connectionDelay => 0.8,            // add 0.8 second of delay between each instruction sent to chrome,
+    BrowserOptions::debugLogger     => 'php://stdout', // will enable verbose mode
 ]
 ```
 
@@ -120,11 +121,12 @@ Options set directly in the `createBrowser` method will be used only for a singl
 
 ```php
 use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Browser\BrowserOptions;
 
 $browserFactory = new BrowserFactory();
 $browser = $browserFactory->createBrowser([
-    'windowSize'   => [1920, 1000],
-    'enableImages' => false,
+    BrowserOptions::windowSize   => [1920, 1000],
+    BrowserOptions::enableImages => false,
 ]);
 
 // this browser will be created without any options
@@ -135,27 +137,29 @@ Options set using the `setOptions` and `addOptions` methods will persist.
 
 ```php
 $browserFactory->setOptions([
-    'windowSize' => [1920, 1000],
+    BrowserOptions::windowSize => [1920, 1000],
 ]);
 
 // both browser will have the same 'windowSize' option
 $browser1 = $browserFactory->createBrowser();
 $browser2 = $browserFactory->createBrowser();
 
-$browserFactory->addOptions(['enableImages' => false]);
+$browserFactory->addOptions([
+    BrowserOptions::enableImages => false
+]);
 
 // this browser will have both the 'windowSize' and 'enableImages' options
 $browser3 = $browserFactory->createBrowser();
 
-$browserFactory->addOptions(['enableImages' => true]);
+$browserFactory->addOptions([
+    BrowserOptions::enableImages => true
+]);
 
 // this browser will have the previous 'windowSize', but 'enableImages' will be true
 $browser4 = $browserFactory->createBrowser();
 ```
 
 #### Available options
-
-Here are the options available for the browser factory:
 
 | Option name               | Default | Description                                                                                  |
 |---------------------------|---------|----------------------------------------------------------------------------------------------|
@@ -178,6 +182,7 @@ Here are the options available for the browser factory:
 | `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                     |
 | `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
 
+Those options are documented as constants in the `HeadlessChromium\Browser\BrowserOptions::class`
 
 ### Persistent Browser
 

--- a/src/Browser/BrowserOptions.php
+++ b/src/Browser/BrowserOptions.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Browser;
+
+abstract class BrowserOptions
+{
+    /**
+     * Delay to apply between each operation for debugging purposes.
+     */
+    public const connectionDelay = 'connectionDelay';
+
+    /**
+     * An array of flags to pass to the command line.
+     */
+    public const customFlags = 'customFlags';
+
+    /**
+     * A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages.
+     */
+    public const debugLogger = 'debugLogger';
+
+    /**
+     * Toggles loading of images.
+     *
+     * Default: true
+     */
+    public const enableImages = 'enableImages';
+
+    /**
+     * An array of environment variables to pass to the process.
+     *
+     * Example: DISPLAY
+     */
+    public const envVariables = 'envVariables';
+
+    /**
+     * An array of custom HTTP headers.
+     */
+    public const headers = 'headers';
+
+    /**
+     * Enable or disable headless mode.
+     *
+     * Default: true
+     */
+    public const headless = 'headless';
+
+    /**
+     * Set chrome to ignore ssl errors.
+     */
+    public const ignoreCertificateErrors = 'ignoreCertificateErrors';
+
+    /**
+     * Whether or not to keep alive the chrome instance when the script terminates.
+     *
+     * Default: false
+     */
+    public const keepAlive = 'keepAlive';
+
+    /**
+     * Enable no sandbox mode, useful to run in a docker container.
+     *
+     * Default: false
+     */
+    public const noSandbox = 'noSandbox';
+
+    /**
+     * Proxy server to use.
+     *
+     * Example: 127.0.0.1:8080
+     */
+    public const proxyServer = 'proxyServer';
+
+    /**
+     * Default timeout in milliseconds for sending sync messages.
+     *
+     * Default: 5000
+     */
+    public const sendSyncDefaultTimeout = 'sendSyncDefaultTimeout';
+
+    /**
+     * Maximum time in seconds to wait for chrome to start.
+     *
+     * Default: 30
+     */
+    public const startupTimeout = 'startupTimeout';
+
+    /**
+     * User agent to use for the whole browser.
+     */
+    public const userAgent = 'userAgent';
+
+    /**
+     * Chrome user data dir.
+     *
+     * Default: a new empty dir is generated temporarily
+     */
+    public const userDataDir = 'userDataDir';
+
+    /**
+     * Size of the window.
+     *
+     * Example: [1920, 1080]
+     */
+    public const windowSize = 'windowSize';
+}

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -29,22 +29,7 @@ class BrowserFactory
     /**
      * Options for browser creation.
      *
-     * - connectionDelay: Delay to apply between each operation for debugging purposes (default: none)
-     * - customFlags: An array of flags to pass to the command line.
-     * - debugLogger: A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages (default: none)
-     * - enableImages: Toggles loading of images (default: true)
-     * - envVariables: An array of environment variables to pass to the process (example DISPLAY variable)
-     * - headers: An array of custom HTTP headers
-     * - headless: Enable or disable headless mode (default: true)
-     * - ignoreCertificateErrors: Set chrome to ignore ssl errors
-     * - keepAlive: Set to `true` to keep alive the chrome instance when the script terminates (default: false)
-     * - noSandbox: Enable no sandbox mode, useful to run in a docker container (default: false)
-     * - proxyServer: Proxy server to use. ex: `127.0.0.1:8080` (default: none)
-     * - sendSyncDefaultTimeout: Default timeout (ms) for sending sync messages (default 5000 ms)
-     * - startupTimeout: Maximum time in seconds to wait for chrome to start (default: 30 sec)
-     * - userAgent: User agent to use for the whole browser
-     * - userDataDir: Chrome user data dir (default: a new empty dir is generated temporarily)
-     * - windowSize: Size of the window. ex: `[1920, 1080]` (default: none)
+     * @see HeadlessChromium\Browser\BrowserOptions::class
      */
     protected $options = [];
 
@@ -58,13 +43,11 @@ class BrowserFactory
      *
      * @see BrowserFactory::$options
      *
-     * @param array|null $options overwrite options for browser creation
-     *
      * @return ProcessAwareBrowser a Browser instance to interact with the new chrome process
      */
-    public function createBrowser(?array $options = null): ProcessAwareBrowser
+    public function createBrowser(?array $overwriteOptions = null): ProcessAwareBrowser
     {
-        $options = $options ?? $this->options;
+        $options = $overwriteOptions ?? $this->options;
 
         // create logger from options
         $logger = self::createLogger($options);

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Browser\BrowserOptions;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Communication\Target;
 
@@ -104,6 +105,15 @@ class BrowserFactoryTest extends BaseTestCase
         $factory->setOptions([]);
 
         $this->assertSame([], $factory->getOptions());
+    }
+
+    public function testBrowserOptions(): void
+    {
+        $factory = new BrowserFactory();
+
+        $factory->addOptions([BrowserOptions::userAgent => 'foo bar']);
+
+        $this->assertSame([BrowserOptions::userAgent => 'foo bar'], $factory->getOptions());
     }
 
     public function testConnectToBrowser(): void


### PR DESCRIPTION
It's easier to use and we can rely on the IDE's auto completion feature.
In future versions, it can be turned into a real `Enum` without breaking backwards compatibility since the usage syntax is the same.

I'm not sure if this is the best approach, but it's better than a huge docblock listing all the options. I'm open to better ideas.

Resolves #332