### PR TITLE
[1.8] Add enum-like class `Keys` with all keyboard custom keys mapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,19 @@ $page->keyboard()
 
 You can press the same key several times in sequence, this is the equivalent to a user pressing and holding the key. The release event, however, will be sent only once per key.
 
+#### Key list
+
+A list of common special keys are available in the `\HeadlessChromium\Input\Keys::class` for easy usage.
+
+```php
+use \HeadlessChromium\Input\Keys;
+
+$page->keyboard()->typeRawKey(Keys::Tab);
+```
+
 #### Key aliases
+
+When typing keys directly as strings, the following aliases are available:
 
 | Key     | Aliases                  |
 |---------|--------------------------|

--- a/src/Input/KeyCodes.php
+++ b/src/Input/KeyCodes.php
@@ -12,11 +12,11 @@
 namespace HeadlessChromium\Input;
 
 /**
- * Holds key constants and their respective bit values.
+ * Holds modifier key constants and their respective bit values.
  *
  * @see https://chromedevtools.github.io/devtools-protocol/1-2/Input/
  */
-abstract class Key
+abstract class KeyCodes
 {
     public const ALT = 1;
     public const CONTROL = 2;

--- a/src/Input/KeyboardKeys.php
+++ b/src/Input/KeyboardKeys.php
@@ -42,22 +42,22 @@ trait KeyboardKeys
      * Aliases for modifier keys, in lowercase.
      */
     protected $keyAliases = [
-        Key::ALT => [
+        KeyCodes::ALT => [
             'alt',
             'altgr',
             'alt gr',
         ],
-        Key::CONTROL => [
+        KeyCodes::CONTROL => [
             'control',
             'ctrl',
             'ctr',
         ],
-        Key::META => [
+        KeyCodes::META => [
             'meta',
             'command',
             'cmd',
         ],
-        Key::SHIFT => [
+        KeyCodes::SHIFT => [
             'shift',
         ],
     ];

--- a/src/Input/Keys.php
+++ b/src/Input/Keys.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Input;
+
+/**
+ * List of constants for common keyboard keys.
+ *
+ * Useful to find valid special keys and how they are written and capitalized
+ */
+abstract class Keys
+{
+    public const Escape = 'Escape';
+    public const Tab = 'Tab';
+    public const CapsLock = 'CapsLock';
+    public const Shift = 'Shift';
+    public const Control = 'Control';
+    public const Meta = 'Meta';
+    public const Command = 'Meta';
+    public const Alt = 'Alt';
+    public const Backspace = 'Backspace';
+    public const Enter = 'Enter';
+    public const Insert = 'Insert';
+    public const Delete = 'Delete';
+    public const Home = 'Home';
+    public const End = 'End';
+    public const PageUp = 'PageUp';
+    public const PageDown = 'PageDown';
+    public const Pause = 'Pause';
+    public const NumLock = 'NumLock';
+    public const ArrowUp = 'ArrowUp';
+    public const ArrowDown = 'ArrowDown';
+    public const ArrowRight = 'ArrowRight';
+    public const ArrowLeft = 'ArrowLeft';
+}

--- a/tests/KeyboardKeysTest.php
+++ b/tests/KeyboardKeysTest.php
@@ -11,11 +11,16 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Input\Keys;
+
 /**
  * @covers \HeadlessChromium\Input\KeyboardKeys
  */
 class KeyboardKeysTest extends BaseTestCase
 {
+    /**
+     * @var KeyboardForTests
+     */
     private $keyboard;
 
     protected function setUp(): void
@@ -51,6 +56,12 @@ class KeyboardKeysTest extends BaseTestCase
             ['Command', 4],
 
             ['Shift',   8],
+
+            [Keys::Alt,     1],
+            [Keys::Control, 2],
+            [Keys::Meta,    4],
+            [Keys::Command, 4],
+            [Keys::Shift,   8],
         ];
     }
 
@@ -65,7 +76,7 @@ class KeyboardKeysTest extends BaseTestCase
     /**
      * @dataProvider keyProvider
      */
-    public function testOnKeyPressAndRelease($key, $expectedKey): void
+    public function testOnKeyPressAndRelease(string $key, string $expectedKey): void
     {
         $this->assertFalse($this->keyboard->isKeyPressed());
         $this->assertEquals(0, $this->keyboard->getModifiers());
@@ -118,7 +129,7 @@ class KeyboardKeysTest extends BaseTestCase
     /**
      * @dataProvider keyCodesProvider
      */
-    public function testGetKeyCode($key, $code): void
+    public function testGetKeyCode(string $key, int $code): void
     {
         $this->keyboard->setCurrentKey($key);
 


### PR DESCRIPTION
Same motivation as #407

Will prevent issues like #313