### PR TITLE
[1.7] Use `command` to guess the chrome executable in Linux

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return null === self::shellExec('google-chrome') ? 'google-chrome' : 'chrome';
+                return null === self::shellExec('google-chrome') ? 'chrome' : 'google-chrome';
         }
     }
 

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -49,7 +49,7 @@ class AutoDiscover
         $registryKey = self::shellExec(
             'reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" /ve'
         );
-        
+
         if (null === $registryKey) {
             return null;
         }
@@ -64,7 +64,7 @@ class AutoDiscover
         try {
             $result = @\shell_exec('command -v '.$command);
 
-            return is_string($result) ? $result : null;
+            return \is_string($result) ? $result : null;
         } catch (\Throwable $e) {
             return null;
         }

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,8 +40,18 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return 'chrome';
+                return self::getFromCommand('google-chrome') ?? 'chrome';
         }
+    }
+
+    private static function getFromCommand(string $command): ?string
+    {
+        try {
+            return \shell_exec('command -v '.$command) ? $command : null;
+        } catch (\Throwable $e) {
+        }
+
+        return null;
     }
 
     private static function getFromRegistry(): ?string

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -55,7 +55,13 @@ class AutoDiscoverTest extends BaseTestCase
             return 'Linux';
         });
 
-        $this->assertSame('chrome', $autoDiscover->guessChromeBinaryPath());
+        $this->assertThat(
+            $autoDiscover->guessChromeBinaryPath(),
+            $this->logicalOr(
+                'chrome',
+                'google-chrome'
+            )
+          );
     }
 
     public function testMac(): void


### PR DESCRIPTION
Testing for the default `google-chrome`.
Fallback to the original `chrome` value.

Resolves #339