### PR TITLE
[1.7] Fix extra http headers

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -182,9 +182,13 @@ class Browser
     }
 
     /**
+     * @param string $targetId
+     *
      * @throws CommunicationException
+     *
+     * @return Page|null
      */
-    public function getPage(string $targetId): ?Page
+    public function getPage($targetId)
     {
         if (\array_key_exists($targetId, $this->pages)) {
             return $this->pages[$targetId];

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -82,10 +82,6 @@ class Browser
 
         // enable target discovery
         $connection->sendMessageSync(new Message('Target.setDiscoverTargets', ['discover' => true]));
-
-        // set up http headers
-        $headers = $connection->getConnectionHttpHeaders();
-        $connection->sendMessageSync(new Message('Network.setExtraHTTPHeaders', $headers));
     }
 
     /**
@@ -186,11 +182,9 @@ class Browser
     }
 
     /**
-     * @param string $targetId
-     *
-     * @return Page|null
+     * @throws CommunicationException
      */
-    public function getPage($targetId)
+    public function getPage(string $targetId): ?Page
     {
         if (\array_key_exists($targetId, $this->pages)) {
             return $this->pages[$targetId];
@@ -224,6 +218,13 @@ class Browser
 
         // Page.setLifecycleEventsEnabled
         $page->getSession()->sendMessageSync(new Message('Page.setLifecycleEventsEnabled', ['enabled' => true]));
+
+        // set up http headers
+        $headers = $this->connection->getConnectionHttpHeaders();
+
+        if (\count($headers) > 0) {
+            $page->setExtraHTTPHeaders($headers);
+        }
 
         // add prescript
         if ($this->pagePreScript) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -176,13 +176,19 @@ class Page
      * @see https://chromedevtools.github.io/devtools-protocol/1-2/Network/#method-setExtraHTTPHeaders
      *
      * @param array<string, string> $headers
+     *
+     * @throws CommunicationException
      */
     public function setExtraHTTPHeaders(array $headers = []): void
     {
-        $this->getSession()->sendMessage(new Message(
+        $response = $this->getSession()->sendMessage(new Message(
             'Network.setExtraHTTPHeaders',
-            $headers
-        ));
+            ['headers' => $headers]
+        ))->waitForResponse();
+
+        if (false === $response->isSuccessful()) {
+            throw new CommunicationException($response->getErrorMessage());
+        }
     }
 
     /**
@@ -190,7 +196,7 @@ class Page
      * @param array  $options
      *                        - strict: make waitForNAvigation to fail if a new navigation is initiated. Default: false
      *
-     * @throws Exception\CommunicationException
+     * @throws CommunicationException
      *
      * @return PageNavigation
      */
@@ -213,7 +219,7 @@ class Page
      *
      * @param string $expression
      *
-     * @throws Exception\CommunicationException
+     * @throws CommunicationException
      *
      * @return PageEvaluation
      */
@@ -849,7 +855,7 @@ class Page
     /**
      * Sets the raw html of the current page.
      *
-     * @throws Exception\CommunicationException
+     * @throws CommunicationException
      */
     public function setHtml(string $html, int $timeout = 3000): void
     {
@@ -869,7 +875,7 @@ class Page
     /**
      * Gets the raw html of the current page.
      *
-     * @throws Exception\CommunicationException
+     * @throws CommunicationException
      */
     public function getHtml(?int $timeout = null): string
     {

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -65,6 +65,7 @@ class BrowserFactoryTest extends BaseTestCase
 
         $factory->addHeader('header_name', 'header_value');
         $factory->addHeaders(['header_name2' => 'header_value2']);
+        $factory->createBrowser()->createPage();
 
         $expected = [
             'header_name' => 'header_value',
@@ -84,6 +85,7 @@ class BrowserFactoryTest extends BaseTestCase
 
         $factory->addHeaders($headers);
         $factory->addOptions($options);
+        $factory->createBrowser()->createPage();
 
         $expected = \array_merge(['headers' => $headers], $options);
 
@@ -91,6 +93,7 @@ class BrowserFactoryTest extends BaseTestCase
 
         // test overwriting
         $factory->addOptions($modifiedOptions);
+        $factory->createBrowser()->createPage();
 
         $expected['userAgent'] = 'foo bar';
 
@@ -98,10 +101,12 @@ class BrowserFactoryTest extends BaseTestCase
 
         // test removing options
         $factory->setOptions($modifiedOptions);
+        $factory->createBrowser()->createPage();
 
         $this->assertSame($modifiedOptions, $factory->getOptions());
 
         $factory->setOptions([]);
+        $factory->createBrowser()->createPage();
 
         $this->assertSame([], $factory->getOptions());
     }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -439,4 +439,14 @@ class PageTest extends BaseTestCase
 
         $this->assertStringContainsString('<div data-name="el"></div>', $page->getHtml());
     }
+
+    public function testSetExtraHTTPHeaders(): void
+    {
+        $factory = new BrowserFactory();
+
+        $page = $factory->createBrowser()->createPage();
+        $page->setExtraHTTPHeaders(['test' => 'test']);
+
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
The correct syntax is `['headers' => $headers]`.
`Network.setHTTPHeaders` must be sent per page instance, after `Network.enable`.

`Page::setExtraHTTPHeaders` will now throw an exception if the response contains an error. The tests were modified to actually try to send the headers to chrome, to make them fail if we get an exception.

Fixes  #404