### PR TITLE
Add lang option for browser creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 1.7.0 (2022-08-24)
+
+* Added option `lang` to browser creation.
+
+
 ## 1.6.1 (2022-05-17)
 
 * Support Monolog 3

--- a/README.md
+++ b/README.md
@@ -157,26 +157,27 @@ $browser4 = $browserFactory->createBrowser();
 
 Here are the options available for the browser factory:
 
-| Option name               | Default | Description                                                                                  |
-|---------------------------|---------|----------------------------------------------------------------------------------------------|
-| `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                 |
-| `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`    |
-| `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages |
-| `enableImages`            | `true`  | Toggles loading of images                                                                    |
-| `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)          |
-| `headers`                 | none    | An array of custom HTTP headers                                                              |
-| `headless`                | `true`  | Enable or disable headless mode                                                              |
-| `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                              |
-| `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                   |
-| `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                  |
-| `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.    |
-| `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections       |
-| `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)  |
-| `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                               |
-| `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |
-| `userAgent`               | none    | User agent to use for the whole browser (see page API for alternative)                       |
-| `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                     |
-| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
+| Option name               | Default | Description                                                                                    |
+|---------------------------|---------|------------------------------------------------------------------------------------------------|
+| `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                   |
+| `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`      |
+| `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages   |
+| `enableImages`            | `true`  | Toggles loading of images                                                                      |
+| `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)            |
+| `headers`                 | none    | An array of custom HTTP headers                                                                |
+| `headless`                | `true`  | Enable or disable headless mode                                                                |
+| `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                                |
+| `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                     |
+| `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                    |
+| `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.      |
+| `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections         |
+| `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)    |
+| `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                                 |
+| `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                            |
+| `userAgent`               | none    | User agent to use for the whole browser (see page API for alternative)                         |
+| `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                       |
+| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                      |
+| `lang`                    | none    | Language as defined in RFC 5646 (e.g. `de-AT`, or multiple like: `de-AT,de,en-US,en,fr-FR,fr`) |
 
 
 ### Persistent Browser

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -11,7 +11,6 @@
 
 namespace HeadlessChromium\Browser;
 
-use HeadlessChromium\Browser;
 use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Exception\OperationTimedOut;
 use HeadlessChromium\Utils;
@@ -280,6 +279,7 @@ class BrowserProcess implements LoggerAwareInterface
     /**
      * Get args for creating chrome's startup command.
      *
+     * @param $binary
      * @param array $options
      *
      * @return array
@@ -368,6 +368,10 @@ class BrowserProcess implements LoggerAwareInterface
         }
         if (\array_key_exists('proxyBypassList', $options)) {
             $args[] = '--proxy-bypass-list='.$options['proxyBypassList'];
+        }
+
+        if (\array_key_exists('lang', $options)) {
+            $args[] = '--lang='.$options['lang'];
         }
 
         // add custom flags

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -59,6 +59,21 @@ class BrowserFactoryTest extends BaseTestCase
         $this->assertEquals('foo bar baz', $response);
     }
 
+    public function testLangOption(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser([
+            'lang' => 'de-AT,de,en-US,en,fr-FR',
+        ]);
+
+        $page = $browser->createPage();
+
+        $response = $page->evaluate('navigator.languages')->getReturnValue();
+
+        $this->assertEquals(['de@at', 'de', 'en-us', 'en', 'fr-fr'], $response);
+    }
+
     public function testAddHeaders(): void
     {
         $factory = new BrowserFactory();


### PR DESCRIPTION
You can set the browser language to use via the --lang command line option. Added it to the possible options for browser creation.

I think it should also be possible via custom flags, but I think there could be a lot of users needing it that don't know the command line flag.

Just found that there is already a 1.7 branch before pushing, so I made it the target branch.
I didn't create an issue first because it was implemented pretty fast. So, no big problem if you don't want to merge it.