### PR TITLE
[1.6] Fix intermittency in `Mouse::findElement()`

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -286,8 +286,6 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\ElementNotFoundException
-     *
-     * @return $this
      */
     public function findElement(Selector $selector, int $position = 1): self
     {
@@ -312,8 +310,11 @@ class Mouse
 
         $offsetX = $visibleArea['pageX'];
         $offsetY = $visibleArea['pageY'];
-        $positionX = \random_int(\ceil($element['left'] - $offsetX), $rightBoundary - $offsetX);
-        $positionY = \random_int(\ceil($element['top'] - $offsetY), $bottomBoundary - $offsetY);
+        $minX = $element['left'] - $offsetX;
+        $minY = $element['top'] - $offsetY;
+
+        $positionX = \floor($minX + (($rightBoundary - $offsetX) - $minX) / 2);
+        $positionY = \ceil($minY + (($bottomBoundary - $offsetY) - $minY) / 2);
 
         $this->move($positionX, $positionY);
 

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -220,7 +220,7 @@ class Mouse
      * @param int $right  The element right boundary
      * @param int $bottom The element bottom boundary
      *
-     * @return self
+     * @return $this
      */
     private function scrollToBoundary(int $right, int $bottom): self
     {
@@ -286,6 +286,8 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\ElementNotFoundException
+     *
+     * @return $this
      */
     public function findElement(Selector $selector, int $position = 1): self
     {


### PR DESCRIPTION
The randomness was resulting in a wrong position intermittently, causing the tests to fail in the navigation after the click.