### PR TITLE
[1.7] Fix command execution in `AutoDiscover`

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return null === self::shellExec('google-chrome') ? 'chrome' : 'google-chrome';
+                return null === self::shellExec('command -v google-chrome') ? 'chrome' : 'google-chrome';
         }
     }
 
@@ -62,7 +62,7 @@ class AutoDiscover
     private static function shellExec(string $command): ?string
     {
         try {
-            $result = @\shell_exec('command -v '.$command);
+            $result = @\shell_exec($command);
 
             return \is_string($result) ? $result : null;
         } catch (\Throwable $e) {

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -22,7 +22,7 @@ class AutoDiscoverTest extends BaseTestCase
 
     protected function setUp(): void
     {
-        if (false !== \array_key_exists('CHROME_PATH', $_SERVER)) {
+        if (\array_key_exists('CHROME_PATH', $_SERVER)) {
             $this->originalEnvPath = $_SERVER['CHROME_PATH'];
 
             unset($_SERVER['CHROME_PATH']);

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -22,9 +22,11 @@ class AutoDiscoverTest extends BaseTestCase
 
     protected function setUp(): void
     {
-        $this->originalEnvPath = null ?? $_SERVER['CHROME_PATH'];
+        if (false !== \array_key_exists('CHROME_PATH', $_SERVER)) {
+            $this->originalEnvPath = $_SERVER['CHROME_PATH'];
 
-        unset($_SERVER['CHROME_PATH']);
+            unset($_SERVER['CHROME_PATH']);
+        }
 
         parent::setUp();
     }


### PR DESCRIPTION
`command -v` was being executed in the call inside `getFromRegistry()`.
Tests were failing when running without the `CHROME_PATH` env var.