### PR TITLE
[1.7] Fix case where the timeout in `setHtml()` isn't respected

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -859,6 +859,8 @@ class Page
      */
     public function setHtml(string $html, int $timeout = 3000): void
     {
+        $time = \hrtime(true) / 1000 / 1000;
+
         $this->getSession()->sendMessageSync(
             new Message(
                 'Page.setDocumentContent',
@@ -866,10 +868,13 @@ class Page
                     'frameId' => $this->getFrameManager()->getMainFrame()->getFrameId(),
                     'html' => $html,
                 ]
-            )
+            ),
+            $timeout
         );
 
-        $this->waitForReload(self::LOAD, $timeout, '');
+        $timeout -= (int) \floor((\hrtime(true) / 1000 / 1000) - $time);
+
+        $this->waitForReload(self::LOAD, \max(0, $timeout), '');
     }
 
     /**


### PR DESCRIPTION
The previous implementation ignores the timeout when sending the html to the browser. The timeout was applied only when waiting for a response. Now it will be respected as the maximum time for the whole operation.

Fixes #432