### PR TITLE
[1.7] Add windows compatibility for unit tests

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -17,6 +17,11 @@ class BaseTestCase extends TestCase
 {
     protected static function sitePath(string $file): string
     {
-        return 'file://'.\realpath(__DIR__.'/resources/static-web/'.$file);
+        $path = \realpath(__DIR__.'/resources/static-web/'.$file);
+        if (\DIRECTORY_SEPARATOR == '\\') {
+            $path = '/'.\str_replace('\\', '/', $path);  // Windows compatibility
+        }
+
+        return 'file://'.$path;
     }
 }


### PR DESCRIPTION
Prior to this change, 2 unit tests were failing.  This change allows for all unit tests to pass on Windows.