### PR TITLE
[1.7] Fix hard coded timeout in `Dom` class

### DIFF
--- a/src/Dom/Dom.php
+++ b/src/Dom/Dom.php
@@ -12,8 +12,7 @@ class Dom extends Node
     public function __construct(Page $page)
     {
         $message = new Message('DOM.getDocument');
-        $stream = $page->getSession()->sendMessage($message);
-        $response = $stream->waitForResponse(1000);
+        $response = $page->getSession()->sendMessageSync($message);
 
         $rootNodeId = $response->getResultData('root')['nodeId'];
 


### PR DESCRIPTION
This will make the `Dom` constructor use the `sendMessageSync()` method like the rest of the class, which uses the timeout set by the option `sendSyncDefaultTimeout` when creating a browser instance with the `BrowserFactory` class.

Fixes #395 