### PR TITLE
[1.7] Fix hard coded timeout in `ResponseReader` class

### DIFF
--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -267,7 +267,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     public function sendMessageSync(Message $message, int $timeout = null): Response
     {
         $responseReader = $this->sendMessage($message);
-        $response = $responseReader->waitForResponse($timeout ?? $this->sendSyncDefaultTimeout);
+        $response = $responseReader->waitForResponse($timeout);
 
         return $response;
     }

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -109,8 +109,7 @@ class ResponseReader
             return $this->getResponse();
         }
 
-        // default 2000ms
-        $timeout = $timeout ?? 2000;
+        $timeout = $timeout ?? $this->connection->getSendSyncDefaultTimeout();
 
         return Utils::tryWithTimeout($timeout * 1000, $this->waitForResponseGenerator());
     }

--- a/src/Communication/Session.php
+++ b/src/Communication/Session.php
@@ -86,7 +86,7 @@ class Session extends EventEmitter
     {
         $responseReader = $this->sendMessage($message);
 
-        $response = $responseReader->waitForResponse($timeout ?? $this->getConnection()->getSendSyncDefaultTimeout());
+        $response = $responseReader->waitForResponse($timeout);
 
         if (!$response) {
             throw new NoResponseAvailable('No response was sent in the given timeout');


### PR DESCRIPTION
`sendSyncDefaultTimeout` is already being used as the default by other methods when calling `ResponseReader::waitForResponse()`.

Fixes #441