### PR TITLE
Wait for the NETWORK_IDLE event instead of LOAD when setting a page's HTML through the setHtml method

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+CHROME_PATH=/usr/bin/chromium

--- a/src/Page.php
+++ b/src/Page.php
@@ -874,7 +874,7 @@ class Page
 
         $timeout -= (int) \floor((\hrtime(true) / 1000 / 1000) - $time);
 
-        $this->waitForReload(self::LOAD, \max(0, $timeout), '');
+        $this->waitForReload(self::NETWORK_IDLE, \max(0, $timeout), '');
     }
 
     /**


### PR DESCRIPTION
I've been playing with this locally for a while, and using NETWORK_IDLE produces far more consistent results when using external CSS/JS in your PDF templates. For example, loading a Google Font through their CDN would sometimes produce a PDF where the font would be missing, but with networkIdle, the font is always there.

If we can't change the default, maybe we should look into passing the event to wait for as an option? That way we can keep LOAD as the default but give us the tools to change it.

Thanks!