### PR TITLE
[1.8] Allow passing the event name to wait for after setting a page's HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,16 @@ $page->evaluate('$(".my.element").html()');
 You can manually inject html to a page using the ```setHtml``` method.
 
 ```php
+// Basic
 $page->setHtml('<p>text</p>');
+
+// Specific timeout & event
+$page->setHtml('<p>text</p>', 10000, Page::NETWORK_IDLE);
 ```
 
-Note that this will not append to the current page html, it will completely replace it.
+When a page's HTML is updated, we'll wait for the page to unload. You can specify how long to wait and which event to wait for through two optional parameters. This defaults to 3000ms and the "load" event.
+
+Note that this method will not append to the current page HTML, it will completely replace it.
 
 #### Get the page HTML
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -857,7 +857,7 @@ class Page
      *
      * @throws CommunicationException
      */
-    public function setHtml(string $html, int $timeout = 3000): void
+    public function setHtml(string $html, int $timeout = 3000, string $eventName = self::LOAD): void
     {
         $this->getSession()->sendMessageSync(
             new Message(
@@ -869,7 +869,7 @@ class Page
             )
         );
 
-        $this->waitForReload(self::LOAD, $timeout, '');
+        $this->waitForReload($eventName, $timeout, '');
     }
 
     /**


### PR DESCRIPTION
Continued from https://github.com/chrome-php/chrome/pull/455