### PR TITLE
[1.7] Stop browser on waitForStartup if devTools failed to start

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -433,7 +433,7 @@ class BrowserProcess implements LoggerAwareInterface
 
                                 return $matches[1];
                             } elseif (\preg_match('/Cannot start http server for devtools\./', $output, $matches)) {
-								throw new \RuntimeException('Devtools could not start');
+								 throw new \RuntimeException('Devtools could not start');
                             } else {
                                 // log
                                 $this->logger->debug('process: ignoring output:'.\trim($output));

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -433,7 +433,7 @@ class BrowserProcess implements LoggerAwareInterface
 
                                 return $matches[1];
                             } elseif (\preg_match('/Cannot start http server for devtools\./', $output, $matches)) {
-								 throw new \RuntimeException('Devtools could not start');
+                                throw new \RuntimeException('Devtools could not start');
                             } else {
                                 // log
                                 $this->logger->debug('process: ignoring output:'.\trim($output));

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -432,6 +432,8 @@ class BrowserProcess implements LoggerAwareInterface
                                 $this->logger->debug('process: ✓ accepted output');
 
                                 return $matches[1];
+                            } elseif (\preg_match('/Cannot start http server for devtools\./', $output, $matches)) {
+								throw new \RuntimeException('Devtools could not start');
                             } else {
                                 // log
                                 $this->logger->debug('process: ignoring output:'.\trim($output));


### PR DESCRIPTION
Because we will never receive "DevTools listening on", so there is no point to continue waiting