### PR TITLE
[1.7] Actually close browser when devtools cannot start

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -433,6 +433,7 @@ class BrowserProcess implements LoggerAwareInterface
 
                                 return $matches[1];
                             } elseif (\preg_match('/Cannot start http server for devtools\./', $output, $matches)) {
+                                $process->stop();
                                 throw new \RuntimeException('Devtools could not start');
                             } else {
                                 // log


### PR DESCRIPTION
Instead of just throwing exception (`catch OperationTimeout` does not catch `RuntimeException`)