### PR TITLE
[1.7] Fixed issue where Chrome 111 and later have different default allowed origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed issue where Chrome 111 and later have different default allowed origins
 
+
 ## 1.7.2 (2023-02-27)
 
 * Fix case where the timeout in `setHtml()` isn't respected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.7.3 (2023-03-XX)
+
+* Fixed issue where Chrome 111 and later have different default allowed origins
 
 ## 1.7.2 (2023-02-27)
 

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -291,6 +291,9 @@ class BrowserProcess implements LoggerAwareInterface
         $args = [
             $binary,
 
+            // allow remote access
+            '--remote-allow-origins=*',
+
             // auto debug port
             '--remote-debugging-port=0',
 


### PR DESCRIPTION
For situations where PHP 7.3 is still required, it would be useful to support the newest version of Chrome which requires a fix for the changes to the allow remote origin argument

This PR just back-ports https://github.com/chrome-php/chrome/pull/497 to the 1.7 branch, which still supports PHP 7.3

