### PR TITLE
[1.11] Add support for the new Chrome headless mode

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -322,7 +322,7 @@ class BrowserProcess implements LoggerAwareInterface
         // enable headless mode
         if (!\array_key_exists('headless', $options) || $options['headless']) {
             // enable the new headless mode available from Chrome 112 and up
-            if ($options['headless'] === 'new') {
+            if ('new' === $options['headless']) {
                 $args[] = '--headless=new';
             } else {
                 $args[] = '--headless';

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -321,7 +321,13 @@ class BrowserProcess implements LoggerAwareInterface
 
         // enable headless mode
         if (!\array_key_exists('headless', $options) || $options['headless']) {
-            $args[] = '--headless';
+            // enable the new headless mode available from Chrome 112 and up
+            if ($options['headless'] === 'new') {
+                $args[] = '--headless=new';
+            } else {
+                $args[] = '--headless';
+            }
+
             $args[] = '--disable-gpu';
             $args[] = '--font-render-hinting=none';
             $args[] = '--hide-scrollbars';

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -322,7 +322,7 @@ class BrowserProcess implements LoggerAwareInterface
         // enable headless mode
         if (!\array_key_exists('headless', $options) || $options['headless']) {
             // enable the new headless mode available from Chrome 112 and up
-            if ('new' === $options['headless']) {
+            if (\array_key_exists('headless', $options) && 'new' === $options['headless']) {
                 $args[] = '--headless=new';
             } else {
                 $args[] = '--headless';


### PR DESCRIPTION
Fixes https://github.com/chrome-php/chrome/issues/498

Reference: https://developer.chrome.com/articles/new-headless/

Imlemented just like Puppeteer:
```
To opt in to the new Headless mode in Puppeteer:

import puppeteer from 'puppeteer';

const browser = await puppeteer.launch({
  headless: 'new',
  // `headless: true` (default) enables old Headless;
  // `headless: 'new'` enables new Headless;
  // `headless: false` enables “headful” mode.
});

const page = await browser.newPage();
await page.goto('https://developer.chrome.com/');

// …

await browser.close();
```

Passing true or not setting the flag at all still enables the old mode. False still disables the headless mode. Passing "new" enables the new headless mode.

From the blog post:

> Currently, passing the --headless command-line flag without an explicit value still activates the old Headless mode — but we plan to change this default to new Headless over time.

This code will work during the transition period and allow users to test their applications against the new set-up

> We plan to completely remove the old Headless from the Chrome binary and stop supporting this mode in Puppeteer later this year. As part of this removal, we’ll make the old Headless available as a separate standalone binary for those users who can’t upgrade yet.

When the old headless mode is removed, the default in this library might have to be switched to "new" (or Chrome will simply map --headless to --headless=new internally, we don't know yet)

