### PR TITLE
[1.9] Added some lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ $navigation->waitForNavigation(Page::DOM_CONTENT_LOADED, 10000);
 Available events (in the order they trigger):
 
 - ``Page::DOM_CONTENT_LOADED``: dom has completely loaded
+- ``Page::FIRST_CONTENTFUL_PAINT``: triggered when the first non-white content element is painted on the screen
+- ``Page::FIRST_IMAGE_PAINT``: triggered when the first image is painted on the screen
+- ``Page::FIRST_MEANINGFUL_PAINT``: triggered when the primary content of a page is visible to the user
+- ``Page::FIRST_PAINT``: triggered when any pixel on the screen is painted, including the browser's default background color
+- ``Page::INIT``: connection to DevTools protocol is initialized
+- ``Page::INTERACTIVE_TIME``: scripts have finished loading and the main thread is no longer blocked by rendering or other tasks
 - ``Page::LOAD``: (default) page and all resources are loaded
 - ``Page::NETWORK_IDLE``: page has loaded, and no network activity has occurred for at least 500ms
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -36,7 +36,15 @@ use HeadlessChromium\PageUtils\ResponseWaiter;
 class Page
 {
     public const DOM_CONTENT_LOADED = 'DOMContentLoaded';
+    public const FIRST_CONTENTFUL_PAINT = 'firstContentfulPaint';
+    public const FIRST_IMAGE_PAINT = 'firstImagePaint';
+    public const FIRST_MEANINGFUL_PAINT = 'firstMeaningfulPaint';
+    public const FIRST_MEANINGFUL_PAINT_CANDIDATE = 'firstMeaningfulPaintCandidate';
+    public const FIRST_PAINT = 'firstPaint';
+    public const INIT = 'init';
+    public const INTERACTIVE_TIME = 'InteractiveTime';
     public const LOAD = 'load';
+    public const NETWORK_ALMOST_IDLE = 'networkAlmostIdle';
     public const NETWORK_IDLE = 'networkIdle';
 
     /**

--- a/src/Page.php
+++ b/src/Page.php
@@ -39,12 +39,10 @@ class Page
     public const FIRST_CONTENTFUL_PAINT = 'firstContentfulPaint';
     public const FIRST_IMAGE_PAINT = 'firstImagePaint';
     public const FIRST_MEANINGFUL_PAINT = 'firstMeaningfulPaint';
-    public const FIRST_MEANINGFUL_PAINT_CANDIDATE = 'firstMeaningfulPaintCandidate';
     public const FIRST_PAINT = 'firstPaint';
     public const INIT = 'init';
     public const INTERACTIVE_TIME = 'InteractiveTime';
     public const LOAD = 'load';
-    public const NETWORK_ALMOST_IDLE = 'networkAlmostIdle';
     public const NETWORK_IDLE = 'networkIdle';
 
     /**


### PR DESCRIPTION
When I log the results of the `getCurrentLifecycle` method, it shows lifecycle events for which there is not yet a constant inside the `Page` class. Constants are sorted alphabetically.

Reference: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/http/tests/inspector-protocol/page/page-lifecycleEvents-expected.txt