### PR TITLE
[1.9] Fix rare crash in getHtml

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -893,16 +893,17 @@ class Page
         try {
             return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
         } catch (Exception\JavascriptException $e) {
-            if (0 === strpos($e->getMessage(), 'Error during javascript evaluation: TypeError: Cannot read properties of null (reading \'outerHTML\')')) {
-                // sometimes after a page reload, for a split second, 
+            if (0 === \strpos($e->getMessage(), 'Error during javascript evaluation: TypeError: Cannot read properties of null (reading \'outerHTML\')')) {
+                // sometimes after a page reload, for a split second,
                 // document.documentElement does not exist
                 // (not sure if its a chromium bug or intentional but either way)
-                usleep(1000); // 1ms seems to be more than enough, unable to reproduce.
+                \usleep(1000); // 1ms seems to be more than enough, unable to reproduce.
                 return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
             }
             throw $e;
         }
     }
+
     /**
      * Read cookies for the current page.
      *

--- a/src/Page.php
+++ b/src/Page.php
@@ -887,6 +887,7 @@ class Page
      * Gets the raw html of the current page.
      *
      * @throws CommunicationException
+     * @throws JavascriptException
      */
     public function getHtml(?int $timeout = null): string
     {

--- a/src/Page.php
+++ b/src/Page.php
@@ -898,6 +898,7 @@ class Page
                 // document.documentElement does not exist
                 // (not sure if its a chromium bug or intentional but either way)
                 \usleep(1000); // 1ms seems to be more than enough, unable to reproduce.
+
                 return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
             }
             throw $e;

--- a/src/Page.php
+++ b/src/Page.php
@@ -894,10 +894,7 @@ class Page
             return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
         } catch (JavascriptException $e) {
             if (0 === \strpos($e->getMessage(), 'Error during javascript evaluation: TypeError: Cannot read properties of null (reading \'outerHTML\')')) {
-                // sometimes after a page reload, for a split second,
-                // document.documentElement does not exist
-                // (not sure if its a chromium bug or intentional but either way)
-                \usleep(1000); // 1ms seems to be more than enough, unable to reproduce.
+                \usleep(1000);
 
                 return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
             }

--- a/src/Page.php
+++ b/src/Page.php
@@ -892,7 +892,7 @@ class Page
     {
         try {
             return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
-        } catch (Exception\JavascriptException $e) {
+        } catch (JavascriptException $e) {
             if (0 === \strpos($e->getMessage(), 'Error during javascript evaluation: TypeError: Cannot read properties of null (reading \'outerHTML\')')) {
                 // sometimes after a page reload, for a split second,
                 // document.documentElement does not exist

--- a/src/Page.php
+++ b/src/Page.php
@@ -890,9 +890,19 @@ class Page
      */
     public function getHtml(?int $timeout = null): string
     {
-        return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
+        try {
+            return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
+        } catch (Exception\JavascriptException $e) {
+            if (0 === strpos($e->getMessage(), 'Error during javascript evaluation: TypeError: Cannot read properties of null (reading \'outerHTML\')')) {
+                // sometimes after a page reload, for a split second, 
+                // document.documentElement does not exist
+                // (not sure if its a chromium bug or intentional but either way)
+                usleep(1000); // 1ms seems to be more than enough, unable to reproduce.
+                return $this->evaluate('document.documentElement.outerHTML')->getReturnValue($timeout);
+            }
+            throw $e;
+        }
     }
-
     /**
      * Read cookies for the current page.
      *


### PR DESCRIPTION
for a split second, documentElement might be missing, causing getHtml() to crash. I had a program that was doing page stuff and calling getHtml() like every 10 milliseconds (100 times per second), and got an unexpected crash. Was able to create a small reproducible sample:
```php
<?php

declare(strict_types=1);
require_once('vendor/autoload.php');
$chromeBinary = "/snap/bin/chromium";
$browser_factory = new \HeadlessChromium\BrowserFactory($chromeBinary);
$browser_factory->setOptions([
    "headless" => true,
    "noSandbox" => true,
    'windowSize'   => [1000, 1000]
]);
$browser = $browser_factory->createBrowser();
$page = $browser->createPage();
for ($i = 0; $i < 100; ++$i) {
    $page->navigate("http://example.com");
    $html = $page->getHtml();
    $page->navigate("http://example.org");
    $html = $page->getHtml();
}
```
consistently crash with:
```
PHP Fatal error:  Uncaught HeadlessChromium\Exception\JavascriptException: Error during javascript evaluation: TypeError: Cannot read properties of null (reading 'outerHTML')
    at <anonymous>:1:26 in /home/hans/projects/ibkr/vendor/chrome-php/chrome/src/PageUtils/PageEvaluation.php:89
Stack trace:
#0 /home/hans/projects/ibkr/vendor/chrome-php/chrome/src/PageUtils/PageEvaluation.php(108): HeadlessChromium\PageUtils\PageEvaluation->waitForResponse()
#1 /home/hans/projects/ibkr/vendor/chrome-php/chrome/src/Page.php(894): HeadlessChromium\PageUtils\PageEvaluation->getReturnValue()
#2 /home/hans/projects/ibkr/test_crash.php(16): HeadlessChromium\Page->getHtml()
#3 {main}
  thrown in /home/hans/projects/ibkr/vendor/chrome-php/chrome/src/PageUtils/PageEvaluation.php on line 89
```