### PR TITLE
[1.9] Use RuntimeException in JavascriptException

### DIFF
--- a/src/Exception/JavascriptException.php
+++ b/src/Exception/JavascriptException.php
@@ -11,6 +11,6 @@
 
 namespace HeadlessChromium\Exception;
 
-class JavascriptException extends \Exception
+class JavascriptException extends \RuntimeException
 {
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -887,7 +887,6 @@ class Page
      * Gets the raw html of the current page.
      *
      * @throws CommunicationException
-     * @throws JavascriptException
      */
     public function getHtml(?int $timeout = null): string
     {

--- a/src/PageUtils/PageEvaluation.php
+++ b/src/PageUtils/PageEvaluation.php
@@ -98,7 +98,6 @@ class PageEvaluation
      * @param int|null $timeout
      *
      * @throws EvaluationFailed
-     * @throws JavascriptException
      *
      * @return mixed
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -15,7 +15,6 @@ use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Dom\Selector\Selector;
 use HeadlessChromium\Exception\CommunicationException;
-use HeadlessChromium\Exception\JavascriptException;
 use HeadlessChromium\Exception\OperationTimedOut;
 
 class Utils

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -97,7 +97,6 @@ class Utils
     /**
      * @throws CommunicationException
      * @throws Exception\EvaluationFailed
-     * @throws JavascriptException
      *
      * @return mixed
      */


### PR DESCRIPTION
Hey there,

I want to semantically separate the exceptions that can be thrown by this package.

When the JavascriptException is thrown, it means that something happened during the execution of the given JavaScript code. If JavascriptException extends RuntimeException, it can be caught by the same try-catch statement to catch other application-specific errors that throws RuntimeException.

JavascriptException currently extends the Exception class, RuntimeException also extends the Exception class. No breaking changes here.