### PR TITLE
[1.10] Allow to remove default chrome flags via option excludedSwitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Here are the options available for the browser factory:
 | `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                     |
 | `userCrashDumpsDir`       | none    | The directory crashpad should store dumps in (crash reporter will be enabled automatically)  |
 | `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
+| `excludedSwitches`        | none    | Chrome flags that should be removed from the default set (example --enable-automation)       |
 
 
 ### Persistent Browser

--- a/README.md
+++ b/README.md
@@ -157,29 +157,29 @@ $browser4 = $browserFactory->createBrowser();
 
 Here are the options available for the browser factory:
 
-| Option name               | Default | Description                                                                                  |
-|---------------------------|---------|----------------------------------------------------------------------------------------------|
-| `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                 |
-| `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`    |
-| `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages |
-| `disableNotifications`    | `false` | Disable browser notifications                                                                |
-| `enableImages`            | `true`  | Toggles loading of images                                                                    |
-| `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)          |
-| `headers`                 | none    | An array of custom HTTP headers                                                              |
-| `headless`                | `true`  | Enable or disable headless mode                                                              |
-| `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                              |
-| `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                   |
-| `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                  |
-| `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.    |
-| `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections       |
-| `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)  |
-| `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                               |
-| `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                          |
-| `userAgent`               | none    | User agent to use for the whole browser (see page API for alternative)                       |
-| `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                     |
-| `userCrashDumpsDir`       | none    | The directory crashpad should store dumps in (crash reporter will be enabled automatically)  |
-| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
-| `excludedSwitches`        | none    | An Array of chrome flags that should be removed from the default set (example --enable-automation)       |
+| Option name               | Default | Description                                                                                        |
+|---------------------------|---------|----------------------------------------------------------------------------------------------------|
+| `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                       |
+| `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`          |
+| `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages       |
+| `disableNotifications`    | `false` | Disable browser notifications                                                                      |
+| `enableImages`            | `true`  | Toggles loading of images                                                                          |
+| `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)                |
+| `headers`                 | none    | An array of custom HTTP headers                                                                    |
+| `headless`                | `true`  | Enable or disable headless mode                                                                    |
+| `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                                    |
+| `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                         |
+| `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                        |
+| `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.          |
+| `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections             |
+| `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)        |
+| `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                                     |
+| `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                                |
+| `userAgent`               | none    | User agent to use for the whole browser (see page API for alternative)                             |
+| `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                           |
+| `userCrashDumpsDir`       | none    | The directory crashpad should store dumps in (crash reporter will be enabled automatically)        |
+| `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                          |
+| `excludedSwitches`        | none    | An array of chrome flags that should be removed from the default set (example --enable-automation) |
 
 
 ### Persistent Browser

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Here are the options available for the browser factory:
 | `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                     |
 | `userCrashDumpsDir`       | none    | The directory crashpad should store dumps in (crash reporter will be enabled automatically)  |
 | `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                    |
-| `excludedSwitches`        | none    | Chrome flags that should be removed from the default set (example --enable-automation)       |
+| `excludedSwitches`        | none    | An Array of chrome flags that should be removed from the default set (example --enable-automation)       |
 
 
 ### Persistent Browser

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Can be used synchronously and asynchronously!
 
 ## Features
 
-- Open chrome or chromium browser from php
+- Open Chrome or Chromium browser from php
 - Create pages and navigate to pages
 - Take screenshots
 - Evaluate javascript on the page
@@ -24,7 +24,7 @@ Happy browsing!
 
 ## Requirements
 
-Requires PHP 7.4-8.2 and a chrome/chromium 65+ executable.
+Requires PHP 7.4-8.2 and a Chrome/Chromium 65+ executable.
 
 Note that the library is only tested on Linux but is compatible with macOS and Windows.
 
@@ -41,14 +41,14 @@ $ composer require chrome-php/chrome
 
 ## Usage
 
-It uses a simple and understandable API to start chrome, to open pages, take screenshots, crawl websites... and almost everything that you can do with chrome as a human.
+It uses a simple and understandable API to start Chrome, to open pages, take screenshots, crawl websites... and almost everything that you can do with Chrome as a human.
 
 ```php
 use HeadlessChromium\BrowserFactory;
 
 $browserFactory = new BrowserFactory();
 
-// starts headless chrome
+// starts headless Chrome
 $browser = $browserFactory->createBrowser();
 
 try {
@@ -70,9 +70,9 @@ try {
 }
 ```
 
-### Using different chrome executable
+### Using different Chrome executable
 
-When starting, the factory will look for the environment variable ``"CHROME_PATH"`` to use as the chrome executable.
+When starting, the factory will look for the environment variable ``"CHROME_PATH"`` to use as the Chrome executable.
 If the variable is not found, it will try to guess the correct executable path according to your OS or use ``"chrome"`` as the default.
 
 You are also able to explicitly set up any executable of your choice when creating a new object. For instance ``"chromium-browser"``:
@@ -102,7 +102,7 @@ Other debug options:
 
 ```php
 [
-    'connectionDelay' => 0.8,            // add 0.8 second of delay between each instruction sent to chrome,
+    'connectionDelay' => 0.8,            // add 0.8 second of delay between each instruction sent to Chrome,
     'debugLogger'     => 'php://stdout', // will enable verbose mode
 ]
 ```
@@ -167,28 +167,28 @@ Here are the options available for the browser factory:
 | `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)                |
 | `headers`                 | none    | An array of custom HTTP headers                                                                    |
 | `headless`                | `true`  | Enable or disable headless mode                                                                    |
-| `ignoreCertificateErrors` | `false` | Set chrome to ignore ssl errors                                                                    |
-| `keepAlive`               | `false` | Set to `true` to keep alive the chrome instance when the script terminates                         |
+| `ignoreCertificateErrors` | `false` | Set Chrome to ignore SSL errors                                                                    |
+| `keepAlive`               | `false` | Set to `true` to keep alive the Chrome instance when the script terminates                         |
 | `noSandbox`               | `false` | Enable no sandbox mode, useful to run in a docker container                                        |
 | `noProxyServer`           | `false` | Don't use a proxy server, always make direct connections. Overrides other proxy settings.          |
 | `proxyBypassList`         | none    | Specifies a list of hosts for whom we bypass proxy settings and use direct connections             |
 | `proxyServer`             | none    | Proxy server to use. usage: `127.0.0.1:8080` (authorisation with credentials does not work)        |
 | `sendSyncDefaultTimeout`  | `5000`  | Default timeout (ms) for sending sync messages                                                     |
-| `startupTimeout`          | `30`    | Maximum time in seconds to wait for chrome to start                                                |
+| `startupTimeout`          | `30`    | Maximum time in seconds to wait for Chrome to start                                                |
 | `userAgent`               | none    | User agent to use for the whole browser (see page API for alternative)                             |
 | `userDataDir`             | none    | Chrome user data dir (default: a new empty dir is generated temporarily)                           |
 | `userCrashDumpsDir`       | none    | The directory crashpad should store dumps in (crash reporter will be enabled automatically)        |
 | `windowSize`              | none    | Size of the window. usage: `$width, $height` - see also Page::setViewport                          |
-| `excludedSwitches`        | none    | An array of chrome flags that should be removed from the default set (example --enable-automation) |
+| `excludedSwitches`        | none    | An array of Chrome flags that should be removed from the default set (example --enable-automation) |
 
 
 ### Persistent Browser
 
-This example shows how to share a single instance of chrome for multiple scripts.
+This example shows how to share a single instance of Chrome for multiple scripts.
 
-The first time the script is started we use the browser factory in order to start chrome, afterwards we save the uri to connect to this browser in the file system.
+The first time the script is started we use the browser factory in order to start Chrome, afterwards we save the uri to connect to this browser in the file system.
 
-The next calls to the script will read the uri from that file in order to connect to the chrome instance instead of creating a new one. If chrome was closed or crashed, a new instance is started again.
+The next calls to the script will read the uri from that file in order to connect to the Chrome instance instead of creating a new one. If Chrome was closed or crashed, a new instance is started again.
 
 ```php
 use \HeadlessChromium\BrowserFactory;
@@ -695,7 +695,7 @@ Advanced usage
 --------------
 
 The library ships with tools that hide all the communication logic but you can use the tools used internally to
-communicate directly with chrome debug protocol.
+communicate directly with Chrome debug protocol.
 
 Example:
 
@@ -703,7 +703,7 @@ Example:
 use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Communication\Message;
 
-// chrome devtools URI
+// Chrome devtools URI
 $webSocketUri = 'ws://127.0.0.1:9222/devtools/browser/xxx';
 
 // create a connection
@@ -744,7 +744,7 @@ You can ease the debugging by setting a delay before each operation is made:
 use HeadlessChromium\Communication\Connection;
 use HeadlessChromium\Browser;
 
-// chrome devtools URI
+// Chrome devtools URI
 $webSocketUri = 'ws://127.0.0.1:9222/devtools/browser/xxx';
 
 // create connection given a WebSocket URI

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -396,7 +396,7 @@ class BrowserProcess implements LoggerAwareInterface
             foreach ($args as $arg) {
                 $toRemove = false;
                 foreach ($options['excludedSwitches'] as $excludedSwitch) {
-                    if (preg_match('/^'.preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
+                    if (\preg_match('/^'.preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
                         $toRemove = true;
                         break;
                     }

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -396,7 +396,7 @@ class BrowserProcess implements LoggerAwareInterface
             foreach ($args as $arg) {
                 $toRemove = false;
                 foreach ($options['excludedSwitches'] as $excludedSwitch) {
-                    if (\preg_match('/^'.preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
+                    if (\preg_match('/^'.\preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
                         $toRemove = true;
                         break;
                     }

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -390,6 +390,23 @@ class BrowserProcess implements LoggerAwareInterface
         // add user data dir to args
         $args[] = '--user-data-dir='.$options['userDataDir'];
 
+        // remove some arguments
+        if (\array_key_exists('excludedSwitches', $options) && \is_array($options['excludedSwitches'])) {
+            $newArgs = [];
+            foreach ($args as $arg) {
+                $toRemove = false;
+                foreach ($options['excludedSwitches'] as $excludedSwitch) {
+                    if (preg_match('/^'.preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
+                        $toRemove = true;
+                        break;
+                    }
+                }
+                if (!$toRemove) {
+                    $newArgs[] = $arg;
+                }
+            }
+        }
+
         return $args;
     }
 

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -392,19 +392,7 @@ class BrowserProcess implements LoggerAwareInterface
 
         // remove some arguments
         if (\array_key_exists('excludedSwitches', $options) && \is_array($options['excludedSwitches'])) {
-            $newArgs = [];
-            foreach ($args as $arg) {
-                $toRemove = false;
-                foreach ($options['excludedSwitches'] as $excludedSwitch) {
-                    if (\preg_match('/^'.\preg_quote($excludedSwitch, '/').'(?:$|=)/', $arg)) {
-                        $toRemove = true;
-                        break;
-                    }
-                }
-                if (!$toRemove) {
-                    $newArgs[] = $arg;
-                }
-            }
+            $args = \array_diff($args, $options['excludedSwitches']);
         }
 
         return $args;

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -36,17 +36,17 @@ class BrowserFactory
      * - envVariables: An array of environment variables to pass to the process (example DISPLAY variable)
      * - headers: An array of custom HTTP headers
      * - headless: Enable or disable headless mode (default: true)
-     * - ignoreCertificateErrors: Set chrome to ignore ssl errors
-     * - keepAlive: Set to `true` to keep alive the chrome instance when the script terminates (default: false)
+     * - ignoreCertificateErrors: Set Chrome to ignore SSL errors
+     * - keepAlive: Set to `true` to keep alive the Chrome instance when the script terminates (default: false)
      * - noSandbox: Enable no sandbox mode, useful to run in a docker container (default: false)
      * - proxyServer: Proxy server to use. ex: `127.0.0.1:8080` (default: none)
      * - sendSyncDefaultTimeout: Default timeout (ms) for sending sync messages (default 5000 ms)
-     * - startupTimeout: Maximum time in seconds to wait for chrome to start (default: 30 sec)
+     * - startupTimeout: Maximum time in seconds to wait for Chrome to start (default: 30 sec)
      * - userAgent: User agent to use for the whole browser
      * - userDataDir: Chrome user data dir (default: a new empty dir is generated temporarily)
      * - userCrashDumpsDir: The directory crashpad should store dumps in (crash reporter will be enabled automatically)
      * - windowSize: Size of the window. ex: `[1920, 1080]` (default: none)
-     * - excludedSwitches: An Array of chrome flags that should be removed from the default set (example --enable-automation)
+     * - excludedSwitches: An array of Chrome flags that should be removed from the default set (example --enable-automation)
      */
     protected $options = [];
 

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -46,6 +46,7 @@ class BrowserFactory
      * - userDataDir: Chrome user data dir (default: a new empty dir is generated temporarily)
      * - userCrashDumpsDir: The directory crashpad should store dumps in (crash reporter will be enabled automatically)
      * - windowSize: Size of the window. ex: `[1920, 1080]` (default: none)
+     * - excludedSwitches: An Array of chrome flags that should be removed from the default set (example --enable-automation)
      */
     protected $options = [];
 


### PR DESCRIPTION
Example, to remove the bar "Chrome is being controlled ...", you must not send the flag `--enable-automation`, so by adding this flag to the excludedSwitches, the bar is absent.