### PR TITLE
[1.10] Add `Node::setHTML`

### DIFF
--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -140,6 +140,17 @@ class Node
         return $response->getResultData('outerHTML');
     }
 
+    public function setHTML(string $outerHTML): void
+    {
+        $message = new Message('DOM.setOuterHTML', [
+            'nodeId' => $this->nodeId,
+            'outerHTML' => $outerHTML,
+        ]);
+        $response = $this->page->getSession()->sendMessageSync($message);
+
+        $this->assertNotError($response);
+    }
+
     public function getText(): string
     {
         return \strip_tags($this->getHTML());

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -173,4 +173,18 @@ class DomTest extends BaseTestCase
         self::assertStringEndsWith(\basename($files[0]), $value1);
         self::assertStringEndsWith(\basename($files[1]), $value2);
     }
+
+    public function testSetHTML(): void
+    {
+        $page = $this->openSitePage('domForm.html');
+
+        $element = $page->dom()->querySelector('#div1');
+        $element->setHTML('<span id="span">hello</span>');
+
+        $value = $page->dom()->querySelector('#span')->getHTML();
+
+        self::assertCount(0, $page->dom()->querySelectorAll('#div1'));
+
+        self::assertEquals('<span id="span">hello</span>', $value);
+    }
 }


### PR DESCRIPTION
Adds a way to override the HTML for an element.

Docs: https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-setOuterHTML

Note: I didn't see any new node ID in the result of this command, although the docs say that it'll be returned.