### PR TITLE
[1.9] Improve stuffs about assertions

### DIFF
--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -56,7 +56,7 @@ class BrowserFactoryTest extends BaseTestCase
 
         $response = $page->evaluate('navigator.userAgent')->getReturnValue();
 
-        self::assertEquals('foo bar baz', $response);
+        self::assertSame('foo bar baz', $response);
     }
 
     public function testAddHeaders(): void

--- a/tests/BrowsingTest.php
+++ b/tests/BrowsingTest.php
@@ -52,12 +52,12 @@ class BrowsingTest extends BaseTestCase
         // initial navigation
         $page = $this->openSitePage('index.html');
         $title = $page->evaluate('document.title')->getReturnValue();
-        self::assertEquals('foo', $title);
+        self::assertSame('foo', $title);
 
         // navigate again
         $page->navigate(self::sitePath('a.html'))->waitForNavigation();
         $title = $page->evaluate('document.title')->getReturnValue();
-        self::assertEquals('a - test', $title);
+        self::assertSame('a - test', $title);
     }
 
     public function testFormSubmission(): void
@@ -72,7 +72,7 @@ class BrowsingTest extends BaseTestCase
         );
 
         $evaluation->waitForPageReload();
-        self::assertEquals('hello', $page->evaluate('document.querySelector("#value").innerHTML')->getReturnValue());
+        self::assertSame('hello', $page->evaluate('document.querySelector("#value").innerHTML')->getReturnValue());
     }
 
     public function testGetCurrentUrl(): void
@@ -81,11 +81,11 @@ class BrowsingTest extends BaseTestCase
 
         $page->getSession()->getConnection()->readData();
 
-        self::assertEquals('about:blank', $page->getCurrentUrl());
+        self::assertSame('about:blank', $page->getCurrentUrl());
 
         $page->navigate(self::sitePath('a.html'))->waitForNavigation();
 
-        self::assertEquals(self::sitePath('a.html'), $page->getCurrentUrl());
+        self::assertSame(self::sitePath('a.html'), $page->getCurrentUrl());
     }
 
     public function testPageNavigationLocalNotFoundUrl(): void
@@ -127,12 +127,12 @@ class BrowsingTest extends BaseTestCase
             // initial navigation
             $page = $this->openSitePage('index.html');
             $title = $page->evaluate('document.title')->getReturnValue();
-            self::assertEquals('foo', $title);
+            self::assertSame('foo', $title);
 
             // navigate again
             $page->navigate(self::sitePath('a.html'))->waitForNavigation();
             $title = $page->evaluate('document.title')->getReturnValue();
-            self::assertEquals('a - test', $title);
+            self::assertSame('a - test', $title);
         }
     }
 

--- a/tests/Communication/ConnectionTest.php
+++ b/tests/Communication/ConnectionTest.php
@@ -64,8 +64,8 @@ class ConnectionTest extends TestCase
         $session = $connection->createSession('baz-qux');
 
         self::assertInstanceOf(Session::class, $session);
-        self::assertEquals('foo-bar', $session->getSessionId());
-        self::assertEquals('baz-qux', $session->getTargetId());
+        self::assertSame('foo-bar', $session->getSessionId());
+        self::assertSame('baz-qux', $session->getTargetId());
         self::assertSame($connection, $session->getConnection());
     }
 

--- a/tests/Communication/MessageTest.php
+++ b/tests/Communication/MessageTest.php
@@ -22,8 +22,8 @@ class MessageTest extends TestCase
     public function testMessage(): void
     {
         $message = new Message('foo', ['bar' => 'baz']);
-        self::assertEquals(Message::getLastMessageId(), $message->getId());
-        self::assertEquals('foo', $message->getMethod());
+        self::assertSame(Message::getLastMessageId(), $message->getId());
+        self::assertSame('foo', $message->getMethod());
         self::assertEquals(['bar' => 'baz'], $message->getParams());
 
         self::assertEquals(
@@ -32,9 +32,9 @@ class MessageTest extends TestCase
         );
 
         $message2 = new Message('qux', ['quux' => 'corge']);
-        self::assertEquals(Message::getLastMessageId(), $message2->getId());
+        self::assertSame(Message::getLastMessageId(), $message2->getId());
         self::assertNotSame($message->getId(), $message2->getId());
-        self::assertEquals('qux', $message2->getMethod());
+        self::assertSame('qux', $message2->getMethod());
         self::assertEquals(['quux' => 'corge'], $message2->getParams());
     }
 }

--- a/tests/Communication/ResponseReaderTest.php
+++ b/tests/Communication/ResponseReaderTest.php
@@ -115,11 +115,11 @@ class ResponseReaderTest extends TestCase
         // wait for response should not read the second message (method:qux.quux)
         $response = $responseReader->waitForResponse(1);
         self::assertEquals(['id' => $message->getId(), 'foo' => 'qux'], $response->getData());
-        self::assertEquals(0, $emitWatcher->emittedCount);
+        self::assertSame(0, $emitWatcher->emittedCount);
 
         // next call to read line should read the second message (method:qux.quux)
         $connection->readLine();
-        self::assertEquals(1, $emitWatcher->emittedCount);
+        self::assertSame(1, $emitWatcher->emittedCount);
     }
 
     public function testExceptionNoResponse(): void

--- a/tests/Communication/ResponseTest.php
+++ b/tests/Communication/ResponseTest.php
@@ -28,7 +28,7 @@ class ResponseTest extends TestCase
         self::assertSame($message, $response->getMessage());
         self::assertTrue($response->isSuccessful());
         self::assertTrue(isset($response['bar']));
-        self::assertEquals('foo', $response['bar']);
+        self::assertSame('foo', $response['bar']);
         self::assertEquals(['id' => $message->getId(), 'bar' => 'foo'], $response->getData());
     }
 

--- a/tests/Communication/SessionTest.php
+++ b/tests/Communication/SessionTest.php
@@ -37,8 +37,8 @@ class SessionTest extends TestCase
         $connection = new Connection($this->mockSocket);
         $session = new Session('foo', 'bar', $connection);
 
-        self::assertEquals('foo', $session->getTargetId());
-        self::assertEquals('bar', $session->getSessionId());
+        self::assertSame('foo', $session->getTargetId());
+        self::assertSame('bar', $session->getSessionId());
         self::assertSame($connection, $session->getConnection());
     }
 

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -56,8 +56,8 @@ class CookieTest extends HttpEnabledTestCase
         self::assertInstanceOf(CookiesCollection::class, $cookies);
         self::assertCount(1, $cookies);
 
-        self::assertEquals($cookies->getAt(0)->getName(), 'foo');
-        self::assertEquals($cookies->getAt(0)->getValue(), 'bar');
+        self::assertSame('foo', $cookies->getAt(0)->getName());
+        self::assertSame('bar', $cookies->getAt(0)->getValue());
     }
 
     public function testGetAllCookies(): void
@@ -70,8 +70,8 @@ class CookieTest extends HttpEnabledTestCase
         self::assertInstanceOf(CookiesCollection::class, $cookies);
         self::assertCount(1, $cookies);
 
-        self::assertEquals($cookies->getAt(0)->getName(), 'foo');
-        self::assertEquals($cookies->getAt(0)->getValue(), 'bar');
+        self::assertSame('foo', $cookies->getAt(0)->getName());
+        self::assertSame('bar', $cookies->getAt(0)->getValue());
     }
 
     public function testSetCookies(): void
@@ -92,9 +92,9 @@ class CookieTest extends HttpEnabledTestCase
         self::assertInstanceOf(CookiesCollection::class, $cookies);
         self::assertCount(1, $cookies);
 
-        self::assertEquals($cookies->getAt(0)->getName(), 'baz');
-        self::assertEquals($cookies->getAt(0)->getValue(), 'qux');
-        self::assertEquals($cookies->getAt(0)->getDomain(), 'foo.bar');
+        self::assertSame('baz', $cookies->getAt(0)->getName());
+        self::assertSame('qux', $cookies->getAt(0)->getValue());
+        self::assertSame('foo.bar', $cookies->getAt(0)->getDomain());
 
         // Set cookie for current page
         $page->navigate(self::sitePath('a.html'))->waitForNavigation();
@@ -108,12 +108,12 @@ class CookieTest extends HttpEnabledTestCase
         self::assertInstanceOf(CookiesCollection::class, $cookies);
         self::assertCount(2, $cookies);
 
-        self::assertEquals($cookies->getAt(1)->getName(), 'quux');
-        self::assertEquals($cookies->getAt(1)->getValue(), 'corge');
-        self::assertEquals($cookies->getAt(1)->getDomain(), 'localhost');
+        self::assertSame('quux', $cookies->getAt(1)->getName());
+        self::assertSame('corge', $cookies->getAt(1)->getValue());
+        self::assertSame('localhost', $cookies->getAt(1)->getDomain());
 
-        self::assertEquals($cookies->getAt(0)->getName(), 'baz');
-        self::assertEquals($cookies->getAt(0)->getValue(), 'qux');
-        self::assertEquals($cookies->getAt(0)->getDomain(), 'foo.bar');
+        self::assertSame('baz', $cookies->getAt(0)->getName());
+        self::assertSame('qux', $cookies->getAt(0)->getValue());
+        self::assertSame('foo.bar', $cookies->getAt(0)->getDomain());
     }
 }

--- a/tests/Cookies/CookiesCollectionTest.php
+++ b/tests/Cookies/CookiesCollectionTest.php
@@ -32,8 +32,8 @@ class CookiesCollectionTest extends TestCase
         $newCookies = $cookies->filterBy('name', 'foo');
 
         self::assertCount(2, $newCookies);
-        self::assertEquals('bar', $newCookies->getAt(0)->getValue());
-        self::assertEquals('baz', $newCookies->getAt(1)->getValue());
+        self::assertSame('bar', $newCookies->getAt(0)->getValue());
+        self::assertSame('baz', $newCookies->getAt(1)->getValue());
     }
 
     public function testFindOneBy(): void
@@ -47,7 +47,7 @@ class CookiesCollectionTest extends TestCase
         $cookieFoo = $cookies->findOneBy('name', 'foo');
         $cookieQux = $cookies->findOneBy('name', 'qux');
 
-        self::assertEquals('bar', $cookieFoo->getValue());
-        self::assertEquals('quux', $cookieQux->getValue());
+        self::assertSame('bar', $cookieFoo->getValue());
+        self::assertSame('quux', $cookieQux->getValue());
     }
 }

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -101,7 +101,7 @@ class DomTest extends BaseTestCase
             ->getReturnValue();
 
         // checks if the input contains the typed text
-        self::assertEquals('bar', $value);
+        self::assertSame('bar', $value);
     }
 
     public function testGetText(): void
@@ -112,7 +112,7 @@ class DomTest extends BaseTestCase
 
         $value = $element->getText();
 
-        self::assertEquals('bar', $value);
+        self::assertSame('bar', $value);
     }
 
     public function testGetAttribute(): void
@@ -123,7 +123,7 @@ class DomTest extends BaseTestCase
 
         $value = $element->getAttribute('type');
 
-        self::assertEquals('foo', $value);
+        self::assertSame('foo', $value);
     }
 
     public function testSetAttribute(): void
@@ -136,7 +136,7 @@ class DomTest extends BaseTestCase
 
         $value = $element->getAttribute('type');
 
-        self::assertEquals('hello', $value);
+        self::assertSame('hello', $value);
     }
 
     public function testUploadFile(): void

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -62,7 +62,7 @@ class KeyboardApiTest extends BaseTestCase
             ->getReturnValue();
 
         // checks if the input contains the typed text
-        self::assertEquals($text, $value);
+        self::assertSame($text, $value);
     }
 
     /**
@@ -127,7 +127,7 @@ class KeyboardApiTest extends BaseTestCase
             ->getReturnValue();
 
         // check if the input contains the typed text twice
-        self::assertEquals($text.$text, $value);
+        self::assertSame($text.$text, $value);
     }
 
     /**
@@ -144,7 +144,7 @@ class KeyboardApiTest extends BaseTestCase
             ->press('b')
             ->release();
 
-        self::assertEquals(0, \count($page->keyboard()->getPressedKeys()));
+        self::assertCount(0, $page->keyboard()->getPressedKeys());
     }
 
     /**

--- a/tests/KeyboardKeysTest.php
+++ b/tests/KeyboardKeysTest.php
@@ -68,20 +68,20 @@ class KeyboardKeysTest extends BaseTestCase
     public function testOnKeyPressAndRelease($key, $expectedKey): void
     {
         self::assertFalse($this->keyboard->isKeyPressed());
-        self::assertEquals(0, $this->keyboard->getModifiers());
+        self::assertSame(0, $this->keyboard->getModifiers());
 
         $this->keyboard->onKeyPress($key);
 
-        self::assertEquals($expectedKey, $this->keyboard->getCurrentKey());
-        self::assertEquals(0, $this->keyboard->getModifiers());
-        self::assertEquals(1, \count($this->keyboard->getPressedKeys()));
+        self::assertSame($expectedKey, $this->keyboard->getCurrentKey());
+        self::assertSame(0, $this->keyboard->getModifiers());
+        self::assertSame(1, \count($this->keyboard->getPressedKeys()));
         self::assertTrue($this->keyboard->isKeyPressed());
 
         $this->keyboard->onKeyRelease($key);
 
-        self::assertEquals($expectedKey, $this->keyboard->getCurrentKey());
-        self::assertEquals(0, \count($this->keyboard->getPressedKeys()));
-        self::assertEquals(0, $this->keyboard->getModifiers());
+        self::assertSame($expectedKey, $this->keyboard->getCurrentKey());
+        self::assertSame(0, \count($this->keyboard->getPressedKeys()));
+        self::assertSame(0, $this->keyboard->getModifiers());
         self::assertFalse($this->keyboard->isKeyPressed());
     }
 
@@ -96,11 +96,11 @@ class KeyboardKeysTest extends BaseTestCase
         $this->keyboard->setCurrentKey('NonModifierKey');
         $this->keyboard->toggleModifierFromKey();
 
-        self::assertEquals($expectedModifier, $this->keyboard->getModifiers());
+        self::assertSame($expectedModifier, $this->keyboard->getModifiers());
 
         $this->keyboard->setCurrentKey($key);
         $this->keyboard->toggleModifierFromKey();
-        self::assertEquals(0, $this->keyboard->getModifiers());
+        self::assertSame(0, $this->keyboard->getModifiers());
     }
 
     public function testToggleModifier(): void
@@ -108,11 +108,11 @@ class KeyboardKeysTest extends BaseTestCase
         $this->keyboard->toggleModifier(0b0001);
         $this->keyboard->toggleModifier(0b0010);
 
-        self::assertEquals(0b0011, $this->keyboard->getModifiers());
+        self::assertSame(0b0011, $this->keyboard->getModifiers());
 
         $this->keyboard->toggleModifier(0b0010);
 
-        self::assertEquals(0b0001, $this->keyboard->getModifiers());
+        self::assertSame(0b0001, $this->keyboard->getModifiers());
     }
 
     /**
@@ -122,6 +122,6 @@ class KeyboardKeysTest extends BaseTestCase
     {
         $this->keyboard->setCurrentKey($key);
 
-        self::assertEquals($code, $this->keyboard->getKeyCode());
+        self::assertSame($code, $this->keyboard->getKeyCode());
     }
 }

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -64,7 +64,7 @@ class MouseApiTest extends BaseTestCase
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
-        self::assertEquals('a - test', $title);
+        self::assertSame('a - test', $title);
     }
 
     /**
@@ -81,16 +81,16 @@ class MouseApiTest extends BaseTestCase
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
-        self::assertEquals(100, $windowScrollY);
-        self::assertEquals(100, $page->mouse()->getPosition()['y']);
+        self::assertSame(100, $windowScrollY);
+        self::assertSame(100, $page->mouse()->getPosition()['y']);
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
 
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
-        self::assertEquals(0, $windowScrollY);
-        self::assertEquals(0, $page->mouse()->getPosition()['y']);
+        self::assertSame(0, $windowScrollY);
+        self::assertSame(0, $page->mouse()->getPosition()['y']);
 
         // try to scroll more than possible
         $page->mouse()->scrollDown(10000);
@@ -117,7 +117,7 @@ class MouseApiTest extends BaseTestCase
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
-        self::assertEquals('a - test', $title);
+        self::assertSame('a - test', $title);
     }
 
     /**
@@ -147,7 +147,7 @@ class MouseApiTest extends BaseTestCase
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
-        self::assertEquals('a - test', $title);
+        self::assertSame('a - test', $title);
     }
 
     /**
@@ -174,7 +174,7 @@ class MouseApiTest extends BaseTestCase
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
-        self::assertEquals($expectedPageTitle, $title);
+        self::assertSame($expectedPageTitle, $title);
     }
 
     /**
@@ -210,7 +210,7 @@ class MouseApiTest extends BaseTestCase
 
         $title = $page->evaluate('document.title')->getReturnValue();
 
-        self::assertEquals('a - test', $title);
+        self::assertSame('a - test', $title);
     }
 
     /**

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -55,8 +55,8 @@ class PageTest extends BaseTestCase
         $value1 = $pageFooBar->evaluate('navigator.userAgent')->getReturnValue();
         $value2 = $pageBarBaz->evaluate('navigator.userAgent')->getReturnValue();
 
-        self::assertEquals('foobar', $value1);
-        self::assertEquals('barbaz', $value2);
+        self::assertSame('foobar', $value1);
+        self::assertSame('barbaz', $value2);
     }
 
     public function testSetTimezone(): void
@@ -148,22 +148,22 @@ class PageTest extends BaseTestCase
         $page->navigate(self::sitePath('a.html'))->waitForNavigation();
         $fooValue = $page->evaluate('navigator.foo')->getReturnValue();
         $barValue = $page->evaluate('navigator.bar')->getReturnValue();
-        self::assertEquals(1, $fooValue);
-        self::assertEquals(11, $barValue);
+        self::assertSame(1, $fooValue);
+        self::assertSame(11, $barValue);
 
         // make sure prescript is not adding again and again on every requests
         $page->navigate(self::sitePath('b.html'))->waitForNavigation();
         $fooValue = $page->evaluate('navigator.foo')->getReturnValue();
         $barValue = $page->evaluate('navigator.bar')->getReturnValue();
-        self::assertEquals(1, $fooValue);
-        self::assertEquals(11, $barValue);
+        self::assertSame(1, $fooValue);
+        self::assertSame(11, $barValue);
 
         // make sure prescript did not pollute other pages
         $page2->navigate(self::sitePath('b.html'))->waitForNavigation();
         $fooValue = $page2->evaluate('navigator.foo')->getReturnValue();
         $barValue = $page2->evaluate('navigator.bar')->getReturnValue();
-        self::assertEquals(null, $fooValue);
-        self::assertEquals(null, $barValue);
+        self::assertNull($fooValue);
+        self::assertNull($barValue);
     }
 
     public function testCallFunction(): void
@@ -174,8 +174,8 @@ class PageTest extends BaseTestCase
         $page = $browser->createPage();
         $evaluation = $page->callFunction('function(a, b) { window.foo = a + b; return window.foo;}', [1, 2]);
 
-        self::assertEquals(3, $evaluation->getReturnValue());
-        self::assertEquals(3, $page->evaluate('window.foo')->getReturnValue());
+        self::assertSame(3, $evaluation->getReturnValue());
+        self::assertSame(3, $page->evaluate('window.foo')->getReturnValue());
     }
 
     public function testCallFunctionPromise(): void
@@ -192,7 +192,7 @@ class PageTest extends BaseTestCase
             })
         }', [1, 2]);
 
-        self::assertEquals(3, $evaluation->getReturnValue());
+        self::assertSame(3, $evaluation->getReturnValue());
     }
 
     public function testEvaluatePromise(): void
@@ -207,7 +207,7 @@ class PageTest extends BaseTestCase
             }, 100);
         })');
 
-        self::assertEquals(11, $evaluation->getReturnValue());
+        self::assertSame(11, $evaluation->getReturnValue());
     }
 
     public function testAddScriptTagContent(): void
@@ -220,7 +220,7 @@ class PageTest extends BaseTestCase
             'content' => 'window.foo = "bar";',
         ])->waitForResponse();
 
-        self::assertEquals('bar', $page->evaluate('window.foo')->getReturnValue());
+        self::assertSame('bar', $page->evaluate('window.foo')->getReturnValue());
     }
 
     public function testAddScriptTagUrl(): void
@@ -240,7 +240,7 @@ class PageTest extends BaseTestCase
         $isIncluded = $page->evaluate('window.testJsIsIncluded')->getReturnValue();
         $scriptSrc = $page->evaluate('document.querySelector("script").getAttribute("src")')->getReturnValue();
 
-        self::assertEquals('isIncluded', $isIncluded);
+        self::assertSame('isIncluded', $isIncluded);
         self::assertStringStartsWith('file://', $scriptSrc);
         self::assertStringEndsWith('/jsInclude.js', $scriptSrc);
     }
@@ -379,10 +379,10 @@ class PageTest extends BaseTestCase
 
         $clip = $page->getFullPageClip();
 
-        self::assertEquals(0, $clip->getX());
-        self::assertEquals(0, $clip->getY());
-        self::assertEquals(900, $clip->getWidth());
-        self::assertEquals(1000, $clip->getHeight());
+        self::assertSame(0, $clip->getX());
+        self::assertSame(0, $clip->getY());
+        self::assertSame(900, $clip->getWidth());
+        self::assertSame(1000, $clip->getHeight());
     }
 
     public function testPdf(): void


### PR DESCRIPTION
# Changed log

- Making the assertion correct argument positions.
- Using the `assertNull` to assert the the expected is same as null.
- Using the `assertSame` to let assertion not be ambiguous.
- Using the `assertCount` to assert the expected countable is same as actual counter.