### PR TITLE
[1.9] Shorten null coalescing operator

### DIFF
--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -65,7 +65,7 @@ class BrowserFactory
      */
     public function createBrowser(?array $options = null): ProcessAwareBrowser
     {
-        $options = $options ?? $this->options;
+        $options ??= $this->options;
 
         // create logger from options
         $logger = self::createLogger($options);

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -109,7 +109,7 @@ class ResponseReader
             return $this->getResponse();
         }
 
-        $timeout = $timeout ?? $this->connection->getSendSyncDefaultTimeout();
+        $timeout ??= $this->connection->getSendSyncDefaultTimeout();
 
         return Utils::tryWithTimeout($timeout * 1000, $this->waitForResponseGenerator());
     }


### PR DESCRIPTION
# Changed log

- Shorten the null operator to make it readable for self assignment.