### PR TITLE
[1.12] Add the ability to screenshot individual elements on the page

### DIFF
--- a/src/Clip.php
+++ b/src/Clip.php
@@ -24,17 +24,17 @@ class Clip
      *
      * @param int|float $x
      * @param int|float $y
-     * @param int|float $height
-     * @param int|float $width
-     * @param int|float $scale
+     * @param int       $height
+     * @param int       $width
+     * @param float     $scale
      */
     public function __construct($x, $y, $width, $height, $scale = 1.0)
     {
         $this->x = (float) $x;
         $this->y = (float) $y;
-        $this->height = (float) $height;
-        $this->width = (float) $width;
-        $this->scale = (float) $scale;
+        $this->height = $height;
+        $this->width = $width;
+        $this->scale = $scale;
     }
 
     /**
@@ -54,7 +54,7 @@ class Clip
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getHeight()
     {
@@ -62,7 +62,7 @@ class Clip
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getWidth()
     {
@@ -94,26 +94,26 @@ class Clip
     }
 
     /**
-     * @param int|float $height
+     * @param int $height
      */
     public function setHeight($height): void
     {
-        $this->height = (float) $height;
+        $this->height = $height;
     }
 
     /**
-     * @param int|float $width
+     * @param int $width
      */
     public function setWidth($width): void
     {
-        $this->width = (float) $width;
+        $this->width = $width;
     }
 
     /**
-     * @param int|float $scale
+     * @param float $scale
      */
     public function setScale($scale): void
     {
-        $this->scale = (float) $scale;
+        $this->scale = $scale;
     }
 }

--- a/src/Clip.php
+++ b/src/Clip.php
@@ -13,15 +13,18 @@ namespace HeadlessChromium;
 
 class Clip
 {
+    /** @var float */
     protected $x;
+    /** @var float */
     protected $y;
+    /** @var int */
     protected $height;
+    /** @var int */
     protected $width;
+    /** @var float */
     protected $scale;
 
     /**
-     * Clip constructor.
-     *
      * @param int|float $x
      * @param int|float $y
      * @param int       $height

--- a/src/Clip.php
+++ b/src/Clip.php
@@ -13,13 +13,13 @@ namespace HeadlessChromium;
 
 class Clip
 {
-    /** @var float */
+    /** @var int|float */
     protected $x;
-    /** @var float */
+    /** @var int|float */
     protected $y;
-    /** @var int */
+    /** @var int|float */
     protected $height;
-    /** @var int */
+    /** @var int|float */
     protected $width;
     /** @var float */
     protected $scale;
@@ -27,21 +27,21 @@ class Clip
     /**
      * @param int|float $x
      * @param int|float $y
-     * @param int       $height
-     * @param int       $width
+     * @param int|float $height
+     * @param int|float $width
      * @param float     $scale
      */
     public function __construct($x, $y, $width, $height, $scale = 1.0)
     {
-        $this->x = (float) $x;
-        $this->y = (float) $y;
+        $this->x = $x;
+        $this->y = $y;
         $this->height = $height;
         $this->width = $width;
         $this->scale = $scale;
     }
 
     /**
-     * @return float
+     * @return int|float
      */
     public function getX()
     {
@@ -49,7 +49,7 @@ class Clip
     }
 
     /**
-     * @return float
+     * @return int|float
      */
     public function getY()
     {
@@ -57,7 +57,7 @@ class Clip
     }
 
     /**
-     * @return int
+     * @return int|float
      */
     public function getHeight()
     {
@@ -65,7 +65,7 @@ class Clip
     }
 
     /**
-     * @return int
+     * @return int|float
      */
     public function getWidth()
     {
@@ -85,7 +85,7 @@ class Clip
      */
     public function setX($x): void
     {
-        $this->x = (float) $x;
+        $this->x = $x;
     }
 
     /**
@@ -93,7 +93,7 @@ class Clip
      */
     public function setY($y): void
     {
-        $this->y = (float) $y;
+        $this->y = $y;
     }
 
     /**

--- a/src/Clip.php
+++ b/src/Clip.php
@@ -22,23 +22,23 @@ class Clip
     /**
      * Clip constructor.
      *
-     * @param int   $x
-     * @param int   $y
-     * @param int   $height
-     * @param int   $width
-     * @param float $scale
+     * @param int|float $x
+     * @param int|float $y
+     * @param int|float $height
+     * @param int|float $width
+     * @param int|float $scale
      */
     public function __construct($x, $y, $width, $height, $scale = 1.0)
     {
-        $this->x = $x;
-        $this->y = $y;
-        $this->height = $height;
-        $this->width = $width;
-        $this->scale = $scale;
+        $this->x = (float) $x;
+        $this->y = (float) $y;
+        $this->height = (float) $height;
+        $this->width = (float) $width;
+        $this->scale = (float) $scale;
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getX()
     {
@@ -46,7 +46,7 @@ class Clip
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getY()
     {
@@ -54,7 +54,7 @@ class Clip
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getHeight()
     {
@@ -62,7 +62,7 @@ class Clip
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getWidth()
     {
@@ -70,7 +70,7 @@ class Clip
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getScale()
     {
@@ -78,42 +78,42 @@ class Clip
     }
 
     /**
-     * @param mixed $x
+     * @param int|float $x
      */
     public function setX($x): void
     {
-        $this->x = $x;
+        $this->x = (float) $x;
     }
 
     /**
-     * @param mixed $y
+     * @param int|float $y
      */
     public function setY($y): void
     {
-        $this->y = $y;
+        $this->y = (float) $y;
     }
 
     /**
-     * @param mixed $height
+     * @param int|float $height
      */
     public function setHeight($height): void
     {
-        $this->height = $height;
+        $this->height = (float) $height;
     }
 
     /**
-     * @param mixed $width
+     * @param int|float $width
      */
     public function setWidth($width): void
     {
-        $this->width = $width;
+        $this->width = (float) $width;
     }
 
     /**
-     * @param mixed $scale
+     * @param int|float $scale
      */
     public function setScale($scale): void
     {
-        $this->scale = $scale;
+        $this->scale = (float) $scale;
     }
 }

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HeadlessChromium\Dom;
 
+use HeadlessChromium\Clip;
 use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Communication\Response;
 use HeadlessChromium\Exception\DomException;
@@ -213,5 +214,21 @@ class Node
         if (!$response->isSuccessful()) {
             throw new DOMException($response->getErrorMessage());
         }
+    }
+
+    public function getClip(): ?Clip
+    {
+        $position = $this->getPosition();
+
+        if (!$position) {
+            return null;
+        }
+
+        return new Clip(
+            $position->getX(),
+            $position->getY(),
+            $position->getWidth(),
+            $position->getHeight(),
+        );
     }
 }

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -178,7 +178,7 @@ class Node
         $this->scrollIntoView();
         $position = $this->getPosition();
         $this->page->mouse()
-            ->move($position->getCenterX(), $position->getCenterY())
+            ->move((int) $position->getCenterX(), (int) $position->getCenterY())
             ->click();
     }
 

--- a/src/Dom/NodePosition.php
+++ b/src/Dom/NodePosition.php
@@ -44,14 +44,14 @@ class NodePosition
         $this->width = $rightBottomX - $leftBottomX;
     }
 
-    public function getX(): int
+    public function getX(): float
     {
-        return (int) $this->x;
+        return (float) $this->x;
     }
 
-    public function getY(): int
+    public function getY(): float
     {
-        return (int) $this->y;
+        return (float) $this->y;
     }
 
     public function getWidth(): int

--- a/src/Dom/NodePosition.php
+++ b/src/Dom/NodePosition.php
@@ -37,21 +37,21 @@ class NodePosition
         $leftBottomX = $points[6];
         $leftBottomY = $points[7];
 
-        $this->x = $leftTopX;
-        $this->y = $leftTopY;
+        $this->x = (float) $leftTopX;
+        $this->y = (float) $leftTopY;
 
-        $this->height = $leftBottomY - $leftTopY;
-        $this->width = $rightBottomX - $leftBottomX;
+        $this->height = (float) ($leftBottomY - $leftTopY);
+        $this->width = (float) ($rightBottomX - $leftBottomX);
     }
 
     public function getX(): float
     {
-        return (float) $this->x;
+        return $this->x;
     }
 
     public function getY(): float
     {
-        return (float) $this->y;
+        return $this->y;
     }
 
     public function getWidth(): int

--- a/src/Dom/NodePosition.php
+++ b/src/Dom/NodePosition.php
@@ -54,23 +54,23 @@ class NodePosition
         return $this->y;
     }
 
-    public function getWidth(): int
+    public function getWidth(): float
     {
-        return (int) $this->width;
+        return $this->width;
     }
 
-    public function getHeight(): int
+    public function getHeight(): float
     {
-        return (int) $this->height;
+        return $this->height;
     }
 
-    public function getCenterX(): int
+    public function getCenterX(): float
     {
-        return (int) ($this->x + ($this->width / 2));
+        return $this->x + ($this->width / 2);
     }
 
-    public function getCenterY(): int
+    public function getCenterY(): float
     {
-        return (int) ($this->y + ($this->height / 2));
+        return $this->y + ($this->height / 2);
     }
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -17,6 +17,7 @@ use HeadlessChromium\Communication\Target;
 use HeadlessChromium\Cookies\Cookie;
 use HeadlessChromium\Cookies\CookiesCollection;
 use HeadlessChromium\Dom\Dom;
+use HeadlessChromium\Dom\Node;
 use HeadlessChromium\Dom\Selector\CssSelector;
 use HeadlessChromium\Dom\Selector\Selector;
 use HeadlessChromium\Exception\CommunicationException;
@@ -671,6 +672,13 @@ class Page
             ->sendMessage(new Message('Page.captureScreenshot', $screenshotOptions));
 
         return new PageScreenshot($responseReader);
+    }
+
+    public function screenshotElement(Node $node): PageScreenshot
+    {
+        return $this->screenshot([
+            'clip' => $node->getClip(),
+        ]);
     }
 
     /**

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -507,4 +507,20 @@ class PageTest extends BaseTestCase
             $page->evaluate('document.body.innerText')->getReturnValue()
         );
     }
+
+    public function testElementScreenshot(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate($this->sitePath('domForm.html'))->waitForNavigation();
+
+        $element = $page->dom()->querySelector('#myform');
+        $screenshot = $page->screenshotElement($element);
+
+        self::assertNotEmpty($screenshot->getBase64());
+        self::assertGreaterThan(4000, \strlen($screenshot->getBase64()));
+    }
 }


### PR DESCRIPTION
Note that currently, the position X and Y properties are not being recorded correctly because the type is `int`, while the original X and Y type can be float. This PR fixes it as well.