### PR TITLE
[1.10] Add "use HeadlessChromium\Dom\Selector\XPathSelector;"

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,8 @@ selectors, you can pass an instance of the required `Selector`.
 Wait for element by XPath selector:
 
 ```php
+use HeadlessChromium\Dom\Selector\XPathSelector;
+
 $page = $browser->createPage();
 $page->navigate('http://example.com')->waitForNavigation();
 


### PR DESCRIPTION
makes it easier to follow sample code, i had to look it up in the source code myself.