### PR TITLE
[1.11] Add `XPathSelector::quote`

### DIFF
--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -46,25 +46,26 @@ final class XPathSelector implements Selector
     public static function quote(string $string): string
     {
         if (false === \strpos($string, '"')) {
-            return '"' . $string . '"';
+            return '"'.$string.'"';
         }
         if (false === \strpos($string, '\'')) {
-            return '\'' . $string . '\'';
+            return '\''.$string.'\'';
         }
         // if the string contains both single and double quotes, construct an
         // expression that concatenates all non-double-quote substrings with
         // the quotes, e.g.:
         //   'foo'"bar" => concat("'foo'", '"bar"')
         $sb = [];
-        while (\strlen($string) > 0) {
+        while ('' !== $string) {
             $bytesUntilSingleQuote = \strcspn($string, '\'');
             $bytesUntilDoubleQuote = \strcspn($string, '"');
             $quoteMethod = ($bytesUntilSingleQuote > $bytesUntilDoubleQuote) ? "'" : '"';
-            $bytesUntilQuote = max($bytesUntilSingleQuote, $bytesUntilDoubleQuote);
-            $sb[] = $quoteMethod . \substr($string, 0, $bytesUntilQuote) . $quoteMethod;
+            $bytesUntilQuote = \max($bytesUntilSingleQuote, $bytesUntilDoubleQuote);
+            $sb[] = $quoteMethod.\substr($string, 0, $bytesUntilQuote).$quoteMethod;
             $string = \substr($string, $bytesUntilQuote);
         }
         $sb = \implode(',', $sb);
-        return 'concat(' . $sb . ')';
+
+        return 'concat('.$sb.')';
     }
 }

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -41,24 +41,24 @@ final class XPathSelector implements Selector
      *
      * @author  Robert Rossney ( https://stackoverflow.com/users/19403/robert-rossney )
      *
-     * @param string $value
+     * @param string $string
      *
      * @return string
      */
-    public static function quote(string $value): string
+    public static function quote(string $string): string
     {
-        if (false === \strpos($value, '"')) {
-            return '"'.$value.'"';
+        if (false === \strpos($string, '"')) {
+            return '"'.$string.'"';
         }
-        if (false === \strpos($value, '\'')) {
-            return '\''.$value.'\'';
+        if (false === \strpos($string, '\'')) {
+            return '\''.$string.'\'';
         }
-        // if the value contains both single and double quotes, construct an
+        // if the string contains both single and double quotes, construct an
         // expression that concatenates all non-double-quote substrings with
         // the quotes, e.g.:
         //    concat("'foo'", '"', "bar")
         $sb = 'concat(';
-        $substrings = \explode('"', $value);
+        $substrings = \explode('"', $string);
         for ($i = 0; $i < \count($substrings); ++$i) {
             $needComma = ($i > 0);
             if ('' !== $substrings[$i]) {

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -33,4 +33,47 @@ final class XPathSelector implements Selector
             $position
         );
     }
+
+    /**
+     * Quotes a string for use in an XPath expression.
+     * 
+     * Example: new XPathSelector("//span[contains(text()," . XPathSelector::quote($string) . ")]")
+     * 
+     * @author  Robert Rossney ( https://stackoverflow.com/users/19403/robert-rossney )
+     * @param string $value
+     * @return string
+     */
+    public static function quote(string $value): string
+    {
+        if (false === strpos($value, '"')) {
+            return '"' . $value . '"';
+        }
+        if (false === strpos($value, '\'')) {
+            return '\'' . $value . '\'';
+        }
+        // if the value contains both single and double quotes, construct an
+        // expression that concatenates all non-double-quote substrings with
+        // the quotes, e.g.:
+        //    concat("'foo'", '"', "bar")
+        $sb = 'concat(';
+        $substrings = explode('"', $value);
+        for ($i = 0; $i < count($substrings); ++$i) {
+            $needComma = ($i > 0);
+            if ($substrings[$i] !== '') {
+                if ($i > 0) {
+                    $sb .= ', ';
+                }
+                $sb .= '"' . $substrings[$i] . '"';
+                $needComma = true;
+            }
+            if ($i < (count($substrings) - 1)) {
+                if ($needComma) {
+                    $sb .= ', ';
+                }
+                $sb .= "'\"'";
+            }
+        }
+        $sb .= ')';
+        return $sb;
+    }
 }

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -39,8 +39,6 @@ final class XPathSelector implements Selector
      *
      * Example: new XPathSelector("//span[contains(text()," . XPathSelector::quote($string) . ")]")
      *
-     * @author  Robert Rossney ( https://stackoverflow.com/users/19403/robert-rossney )
-     *
      * @param string $string
      *
      * @return string
@@ -48,35 +46,25 @@ final class XPathSelector implements Selector
     public static function quote(string $string): string
     {
         if (false === \strpos($string, '"')) {
-            return '"'.$string.'"';
+            return '"' . $string . '"';
         }
         if (false === \strpos($string, '\'')) {
-            return '\''.$string.'\'';
+            return '\'' . $string . '\'';
         }
         // if the string contains both single and double quotes, construct an
         // expression that concatenates all non-double-quote substrings with
         // the quotes, e.g.:
-        //    concat("'foo'", '"', "bar")
-        $sb = 'concat(';
-        $substrings = \explode('"', $string);
-        for ($i = 0; $i < \count($substrings); ++$i) {
-            $needComma = ($i > 0);
-            if ('' !== $substrings[$i]) {
-                if ($i > 0) {
-                    $sb .= ', ';
-                }
-                $sb .= '"'.$substrings[$i].'"';
-                $needComma = true;
-            }
-            if ($i < (\count($substrings) - 1)) {
-                if ($needComma) {
-                    $sb .= ', ';
-                }
-                $sb .= "'\"'";
-            }
+        //   'foo'"bar" => concat("'foo'", '"bar"')
+        $sb = [];
+        while (\strlen($string) > 0) {
+            $bytesUntilSingleQuote = \strcspn($string, '\'');
+            $bytesUntilDoubleQuote = \strcspn($string, '"');
+            $quoteMethod = ($bytesUntilSingleQuote > $bytesUntilDoubleQuote) ? "'" : '"';
+            $bytesUntilQuote = max($bytesUntilSingleQuote, $bytesUntilDoubleQuote);
+            $sb[] = $quoteMethod . \substr($string, 0, $bytesUntilQuote) . $quoteMethod;
+            $string = \substr($string, $bytesUntilQuote);
         }
-        $sb .= ')';
-
-        return $sb;
+        $sb = \implode(',', $sb);
+        return 'concat(' . $sb . ')';
     }
 }

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -36,37 +36,39 @@ final class XPathSelector implements Selector
 
     /**
      * Quotes a string for use in an XPath expression.
-     * 
+     *
      * Example: new XPathSelector("//span[contains(text()," . XPathSelector::quote($string) . ")]")
-     * 
+     *
      * @author  Robert Rossney ( https://stackoverflow.com/users/19403/robert-rossney )
+     *
      * @param string $value
+     *
      * @return string
      */
     public static function quote(string $value): string
     {
-        if (false === strpos($value, '"')) {
-            return '"' . $value . '"';
+        if (false === \strpos($value, '"')) {
+            return '"'.$value.'"';
         }
-        if (false === strpos($value, '\'')) {
-            return '\'' . $value . '\'';
+        if (false === \strpos($value, '\'')) {
+            return '\''.$value.'\'';
         }
         // if the value contains both single and double quotes, construct an
         // expression that concatenates all non-double-quote substrings with
         // the quotes, e.g.:
         //    concat("'foo'", '"', "bar")
         $sb = 'concat(';
-        $substrings = explode('"', $value);
-        for ($i = 0; $i < count($substrings); ++$i) {
+        $substrings = \explode('"', $value);
+        for ($i = 0; $i < \count($substrings); ++$i) {
             $needComma = ($i > 0);
-            if ($substrings[$i] !== '') {
+            if ('' !== $substrings[$i]) {
                 if ($i > 0) {
                     $sb .= ', ';
                 }
-                $sb .= '"' . $substrings[$i] . '"';
+                $sb .= '"'.$substrings[$i].'"';
                 $needComma = true;
             }
-            if ($i < (count($substrings) - 1)) {
+            if ($i < (\count($substrings) - 1)) {
                 if ($needComma) {
                     $sb .= ', ';
                 }
@@ -74,6 +76,7 @@ final class XPathSelector implements Selector
             }
         }
         $sb .= ')';
+
         return $sb;
     }
 }


### PR DESCRIPTION
method to quote strings in XPath, similar to PDO::quote() and mysqli::real_escape_string()

Quoting strings in XPath is surprisingly difficult to do in the edge case where the string contains both double-quotes and single-quotes. Got the algorithm from https://stackoverflow.com/a/1352556/1067003