### PR TITLE
[1.10] Fix xpath php-string-to-javascript-string

### DIFF
--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -19,11 +19,11 @@ final class XPathSelector implements Selector
 
     public function expressionCount(): string
     {
-        return 'document.evaluate('. json_encode($this->expression, JSON_THROW_ON_ERROR) .', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength';
+        return 'document.evaluate('.\json_encode($this->expression, \JSON_THROW_ON_ERROR).', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength';
     }
 
     public function expressionFindOne(int $position): string
     {
-        return 'document.evaluate('. json_encode($this->expression . "[{$position}]", JSON_THROW_ON_ERROR) .', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue';
+        return 'document.evaluate('.\json_encode($this->expression."[{$position}]", \JSON_THROW_ON_ERROR).', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue';
     }
 }

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -19,11 +19,11 @@ final class XPathSelector implements Selector
 
     public function expressionCount(): string
     {
-        return 'document.evaluate('.\json_encode($this->expression, \JSON_THROW_ON_ERROR).', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength';
+        return 'document.evaluate('.\json_encode($this->expression, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE).', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength';
     }
 
     public function expressionFindOne(int $position): string
     {
-        return 'document.evaluate('.\json_encode($this->expression."[{$position}]", \JSON_THROW_ON_ERROR).', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue';
+        return 'document.evaluate('.\json_encode($this->expression."[{$position}]", \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE).', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue';
     }
 }

--- a/src/Dom/Selector/XPathSelector.php
+++ b/src/Dom/Selector/XPathSelector.php
@@ -19,18 +19,11 @@ final class XPathSelector implements Selector
 
     public function expressionCount(): string
     {
-        return \sprintf(
-            'document.evaluate("%s", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength',
-            \addslashes($this->expression)
-        );
+        return 'document.evaluate('. json_encode($this->expression, JSON_THROW_ON_ERROR) .', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength';
     }
 
     public function expressionFindOne(int $position): string
     {
-        return \sprintf(
-            'document.evaluate("%s[%d]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue',
-            \addslashes($this->expression),
-            $position
-        );
+        return 'document.evaluate('. json_encode($this->expression . "[{$position}]", JSON_THROW_ON_ERROR) .', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue';
     }
 }


### PR DESCRIPTION
TL;DR: addslashes() is not the correct way to convert a php-string to a javascript string. json_encode() is.

For example, addslashes will fail on the PHP string "foo".chr(10)."bar" , the old addslashes() code will convert it into "foo
bar"

which is a javascript syntax error.

Previously this code would fail:
```php
$str = "foo".chr(10)."bar";
$xps = new XPathSelector("//span[contains(text(),'" . $str . "')]");
var_dump($xps->expressionCount());
```
it would generate a javascript syntax error:
```
string(134) "document.evaluate("//span[contains(text(),\'foo
bar\')]", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshot Length"
```
now it generates valid javascript:
```
string(133) "document.evaluate("//span[contains(text(),'foo\nbar')]", document,
null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null).snapshotLength"
```