### PR TITLE
fix guessChromeBinaryPath on Ubuntu Linux + add Chromium

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return \explode("\n", (string) self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome';
+                return rtrim(\explode("\n", (string) self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome');
         }
     }
 

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return explode("\n", (string)self::shellExec("bash -c 'command -v google-chrome chrome chromium chromium-browser'"), 2)[0] ?: 'chrome';
+                return explode("\n", (string)self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome';
         }
     }
 

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return rtrim(\explode("\n", (string) self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome');
+                return \rtrim(\explode("\n", (string) self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome');
         }
     }
 

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return null === self::shellExec('command -v google-chrome') ? 'chrome' : 'google-chrome';
+                return explode("\n", (string)self::shellExec("bash -c 'command -v google-chrome chrome chromium chromium-browser'"), 2)[0] ?: 'chrome';
         }
     }
 

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return explode("\n", (string)self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome';
+                return \explode("\n", (string) self::shellExec("bash -c 'command -v google-chrome chrome chromium-browser chromium'"), 2)[0] ?: 'chrome';
         }
     }
 

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -61,7 +61,9 @@ class AutoDiscoverTest extends BaseTestCase
             $autoDiscover->guessChromeBinaryPath(),
             $this->logicalOr(
                 'chrome',
-                '/usr/bin/google-chrome'
+                '/usr/bin/google-chrome',
+                '/usr/bin/chromium-browser',
+                '/snap/bin/chromium'
             )
         );
     }

--- a/tests/AutoDiscoverTest.php
+++ b/tests/AutoDiscoverTest.php
@@ -61,7 +61,7 @@ class AutoDiscoverTest extends BaseTestCase
             $autoDiscover->guessChromeBinaryPath(),
             $this->logicalOr(
                 'chrome',
-                'google-chrome'
+                '/usr/bin/google-chrome'
             )
         );
     }


### PR DESCRIPTION
on Ubutu Linux, "command" is a bash builtin, not a standalone binary, and shell_exec() tries to find the "command" binary and fails, thus the original code never worked on Ubuntu Linux (I think the same is true for the entire Debian-derived family of operating systems, but don't quote me on that),  fixing that by doing `bash -c 'command...`  instead.

Also added chromium support, for those who have Chromium but not Chrome installed.

It will look for Chrome first, and if it cannot find Chrome, it will look for Chromium second, and if all fails, it falls back to hardcoded "chrome".