### PR TITLE
Adding support for http endpoint in addition to the websocket

### DIFF
--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -107,19 +107,19 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         // create socket client
         if (\is_string($socketClient)) {
 
-            if (\in_array(\parse_url($socketClient, PHP_URL_SCHEME), ['http', 'https'])) {
+            if (\in_array(\parse_url($socketClient, \PHP_URL_SCHEME), ['http', 'https'])) {
 
                 $configURL = $socketClient.'/json/version';
 
                 if (!\function_exists('curl_init')) {
-                    throw new \Exception("curl is not available");
+                    throw new \Exception('curl is not available');
                 }
 
-                $curl = curl_init($configURL);
-                curl_setopt($curl, CURLOPT_URL, $configURL);
-                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-                $resp = curl_exec($curl);
-                curl_close($curl);
+                $curl = \curl_init($configURL);
+                \curl_setopt($curl, CURLOPT_URL, $configURL);
+                \curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                $resp = \curl_exec($curl);
+                \curl_close($curl);
 
                 if (false === $resp) {
                     throw new \Exception("Unable to request $configURL");

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -107,33 +107,23 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         // create socket client
         if (\is_string($socketClient)) {
 
-            $parsedUrl = parse_url($socketClient);
-            if (isset($parsedUrl['scheme']) && ($parsedUrl['scheme']==='http' or $parsedUrl['scheme']==='https'))
+            if (\in_array(\parse_url($socketClient, PHP_URL_SCHEME), ['http', 'https']))
             {
 
                 $configURL = $socketClient.'/json/version';
 
-                $curl = curl_init($configURL);
-                curl_setopt($curl, CURLOPT_URL, $configURL);
-                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-                $resp = curl_exec($curl);
+                $resp = \file_get_contents($configURL);
 
                 if ($resp === false) {
-                    $err = curl_error($curl);
-                    curl_close($curl);
-
                     throw new \Exception("Unable to request $configURL");
                 }
-                else {
-                    curl_close($curl);
-                }
 
-                $json_resp = json_decode($resp);
+                $json_resp = \json_decode($resp);
                 if (is_null($json_resp)) {
                     throw new \Exception("Invalid JSON response from $configURL");
                 }
 
-                if (!property_exists($json_resp, 'webSocketDebuggerUrl')) {
+                if (!\property_exists($json_resp, 'webSocketDebuggerUrl')) {
                     throw new \Exception("Websocket debugger URL not found in response from $configURL");
                 }
 

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -106,9 +106,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
 
         // create socket client
         if (\is_string($socketClient)) {
-
             if (\in_array(\parse_url($socketClient, \PHP_URL_SCHEME), ['http', 'https'])) {
-
                 $configURL = $socketClient.'/json/version';
 
                 if (!\function_exists('curl_init')) {
@@ -135,7 +133,6 @@ class Connection extends EventEmitter implements LoggerAwareInterface
                 }
 
                 $socketClient = $json_resp->webSocketDebuggerUrl;
-
             }
 
             $socketClient = new Wrench(new WrenchBaseClient($socketClient, 'http://127.0.0.1'), $this->logger);

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -111,7 +111,15 @@ class Connection extends EventEmitter implements LoggerAwareInterface
 
                 $configURL = $socketClient.'/json/version';
 
-                $resp = \file_get_contents($configURL);
+                if (!\function_exists('curl_init')) {
+                    throw new \Exception("curl is not available");
+                }
+
+                $curl = curl_init($configURL);
+                curl_setopt($curl, CURLOPT_URL, $configURL);
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                $resp = curl_exec($curl);
+                curl_close($curl);
 
                 if (false === $resp) {
                     throw new \Exception("Unable to request $configURL");

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -116,8 +116,8 @@ class Connection extends EventEmitter implements LoggerAwareInterface
                 }
 
                 $curl = \curl_init($configURL);
-                \curl_setopt($curl, CURLOPT_URL, $configURL);
-                \curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+                \curl_setopt($curl, \CURLOPT_URL, $configURL);
+                \curl_setopt($curl, \CURLOPT_RETURNTRANSFER, true);
                 $resp = \curl_exec($curl);
                 \curl_close($curl);
 

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -107,19 +107,18 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         // create socket client
         if (\is_string($socketClient)) {
 
-            if (\in_array(\parse_url($socketClient, PHP_URL_SCHEME), ['http', 'https']))
-            {
+            if (\in_array(\parse_url($socketClient, PHP_URL_SCHEME), ['http', 'https'])) {
 
                 $configURL = $socketClient.'/json/version';
 
                 $resp = \file_get_contents($configURL);
 
-                if ($resp === false) {
+                if (false === $resp) {
                     throw new \Exception("Unable to request $configURL");
                 }
 
                 $json_resp = \json_decode($resp);
-                if (is_null($json_resp)) {
+                if (null === $json_resp) {
                     throw new \Exception("Invalid JSON response from $configURL");
                 }
 


### PR DESCRIPTION
In order to use Chrome Headless you need to know the `webSocketDebuggerUrl`.
This address can be retrieved by requesting `/json/version` as mentioned at https://chromedevtools.github.io/devtools-protocol/.

With this PR the goal is to support both the websocket address and the HTTP endpoint.