### PR TITLE
[1.13] `getBase64` returns string

### DIFF
--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -41,9 +41,9 @@ abstract class AbstractBinaryInput
     /**
      * Get base64 representation of the file.
      *
-     * @return mixed
+     * @return string
      */
-    public function getBase64(int $timeout = null)
+    public function getBase64(int $timeout = null): string
     {
         $response = $this->responseReader->waitForResponse($timeout);
 


### PR DESCRIPTION
... reading the code, it suggest the return can either be string or null, but with the isSuccessful() check, i think it can only ever return string?

not 100% sure if it should be `string` or `?string`  but we can narrow it down from `mixed`.