### PR TITLE
ADD: headless=new option and compatibillaty

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -324,12 +324,14 @@ class BrowserProcess implements LoggerAwareInterface
         }
 
         // enable headless mode
-        if (!\array_key_exists('headless', $options) || $options['headless']) {
-            $args[] = '--headless';
-            $args[] = '--disable-gpu';
-            $args[] = '--font-render-hinting=none';
-            $args[] = '--hide-scrollbars';
-            $args[] = '--mute-audio';
+        if (!array_key_exists('headless', $options) || $options['headless']) {
+            $args[] = $options['headless'] === 'new' ? '--headless=new' : '--headless';
+            $args = array_merge($args, [
+                '--disable-gpu',
+                '--font-render-hinting=none',
+                '--hide-scrollbars',
+                '--mute-audio'
+            ]);
         }
 
         // disable loading of images (currently can't be done via devtools, only CLI)
@@ -394,6 +396,8 @@ class BrowserProcess implements LoggerAwareInterface
         if (\array_key_exists('excludedSwitches', $options) && \is_array($options['excludedSwitches'])) {
             $args = \array_diff($args, $options['excludedSwitches']);
         }
+
+        dd($args);
 
         return $args;
     }

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -133,4 +133,17 @@ class BrowserFactoryTest extends BaseTestCase
         $target = $browser2->getTarget($page2TargetId);
         self::assertInstanceOf(Target::class, $target);
     }
+
+    public function testHeadlessNewModeOptionExists(): void
+    {
+        $launchOptions = [
+            'headless' => 'new'
+        ];
+
+        $factory = new BrowserFactory();
+
+        $factory->addOptions($launchOptions);
+
+        self::assertSame($launchOptions, $factory->getOptions());
+    }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -507,4 +507,24 @@ class PageTest extends BaseTestCase
             $page->evaluate('document.body.innerText')->getReturnValue()
         );
     }
+
+    public function testNewHeadlessModeNavigation(): void
+    {
+        $factory = new BrowserFactory();
+
+        $factory->addOptions([
+            'headless' => 'new'
+        ]);
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate(self::sitePath(self::WAIT_FOR_ELEMENT_RESOURCE_FILE))->waitForNavigation();
+
+        self::assertStringNotContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
+
+        $page->waitUntilContainsElement('div[data-name=\"el\"]');
+
+        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
+    }
 }


### PR DESCRIPTION
Recently, I used this package to scrape a website that requires users to log in.

My target website uses cookies, IndexedDB, and SessionStorage, and sometimes, even with a logged-in browser with user-data-directory, I still see the login form. In the DevTools of headless chrome , there are many errors indicating that Chrome cannot access cookie storage or IndexedDB. After this, I tried crawling with Node.js and the Puppeteer library, but the issue remained. I then started browsing the Puppeteer issues and found some similar to mine:

puppeteer/puppeteer#12498

puppeteer/puppeteer#1316

puppeteer/puppeteer#1268

puppeteer/puppeteer#1270

puppeteer/puppeteer#5612

[Chrome Developers Docs About headless=new](https://developer.chrome.com/docs/chromium/new-headless)

In the first link, a user said that by setting the Puppeteer launch option to headless: 'new', the issue was resolved. I did the same and set the headless mode to 'new', which solved my problems. However, when I wanted to try the new headless mode with the chrome-php/chrome package, I realized that the library does not support this feature. So, I created this pull request and made the necessary changes.

About Tests
I wrote only two tests, as I believe that is enough to test the new code. However, if you think there are any missing points, please let me know, and I will add more tests.

About Documentation
I am waiting for this pull request to be merged into the main code, after which I will add proper documentation for the new headless mode feature.