### PR TITLE
[1.12] AbstractBinaryInput::getRawBinary()

### DIFF
--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -58,13 +58,14 @@ abstract class AbstractBinaryInput
      * Get raw binary data.
      *
      * @param int|null $timeout
+     *
      * @return string
      */
     public function getRawBinary(int $timeout = null): string
     {
-        return base64_decode($this->getBase64($timeout), true);
+        return \base64_decode($this->getBase64($timeout), true);
     }
-    
+
     /**
      * Save data to the given file.
      *
@@ -100,7 +101,7 @@ abstract class AbstractBinaryInput
             }
         }
 
-        $file = \fopen($path, 'wb');
+        $file = \fopen($path, 'w');
         \stream_filter_append($file, 'convert.base64-decode');
         \fwrite($file, $response->getResultData('data'));
         \fclose($file);

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -55,6 +55,17 @@ abstract class AbstractBinaryInput
     }
 
     /**
+     * Get raw binary data.
+     *
+     * @param int|null $timeout
+     * @return string
+     */
+    public function getRawBinary(int $timeout = null): string
+    {
+        return base64_decode($this->getBase64($timeout), true);
+    }
+    
+    /**
      * Save data to the given file.
      *
      * @param string $path
@@ -89,7 +100,7 @@ abstract class AbstractBinaryInput
             }
         }
 
-        $file = \fopen($path, 'w');
+        $file = \fopen($path, 'wb');
         \stream_filter_append($file, 'convert.base64-decode');
         \fwrite($file, $response->getResultData('data'));
         \fclose($file);

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -41,9 +41,11 @@ abstract class AbstractBinaryInput
     /**
      * Get base64 representation of the file.
      *
+     * @param int|null $timeout
+     *
      * @return mixed
      */
-    public function getBase64(int $timeout = null)
+    public function getBase64(?int $timeout = null)
     {
         $response = $this->responseReader->waitForResponse($timeout);
 
@@ -70,6 +72,7 @@ abstract class AbstractBinaryInput
      * Save data to the given file.
      *
      * @param string $path
+     * @param int $timeout
      *
      * @throws FilesystemException
      * @throws ScreenshotFailed


### PR DESCRIPTION
simple complement to AbstractBinaryInput::getBase64()

as usual, naming is hard, some possible names:
getBinary
getRawBinary
getRawBinaryData
getRawData
getString
getRawString
~

GitHub CoPilot seems to prefer "getRawData()" fwiw.