### PR TITLE
[1.12] IteratorAggregate for Cookie

### DIFF
--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -11,7 +11,7 @@
 
 namespace HeadlessChromium\Cookies;
 
-class Cookie implements \ArrayAccess
+class Cookie implements \ArrayAccess, \IteratorAggregate
 {
     /**
      * @var array
@@ -101,5 +101,11 @@ class Cookie implements \ArrayAccess
         $params['value'] = $value;
 
         return new self($params);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
     }
 }

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -103,8 +103,7 @@ class Cookie implements \ArrayAccess, \IteratorAggregate
         return new self($params);
     }
 
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -103,7 +103,7 @@ class Cookie implements \ArrayAccess, \IteratorAggregate
         return new self($params);
     }
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }


### PR DESCRIPTION
Was in a situation where I wanted a plain-array version of Cookie, was a little sad that I couldn't unpack it. Previously:

```
var_dump([...$cookie]);

object(TypeError)#1261 (7) {
  ["message":protected]=>
  string(44) "Only arrays and Traversables can be unpacked"
  ["string":"Error":private]=>
  string(0) ""
  ["code":protected]=>
  int(0)
(...)
```
Now:
```
var_dump([...$cookie]);
array(13) {
  ["name"]=>
  string(9) "PHPSESSID"
  ["value"]=>
  string(26) "<censored>"
  ["domain"]=>
  string(13) "<censored>"
  ["path"]=>
  string(1) "/"
  ["expires"]=>
  int(-1)
  ["size"]=>
  int(35)
  ["httpOnly"]=>
  bool(true)
  ["secure"]=>
  bool(false)
  ["session"]=>
  bool(true)
  ["priority"]=>
  string(6) "Medium"
  ["sameParty"]=>
  bool(false)
  ["sourceScheme"]=>
  string(6) "Secure"
  ["sourcePort"]=>
  int(443)
}
```