### PR TITLE
[1.15] Fix precision loss (int vs float mixup)

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -31,8 +31,8 @@ class Mouse
      */
     protected $page;
 
-    protected $x = 0;
-    protected $y = 0;
+    protected $x = 0.0;
+    protected $y = 0.0;
 
     protected $button = self::BUTTON_NONE;
 
@@ -54,7 +54,7 @@ class Mouse
      *
      * @return $this
      */
-    public function move(int $x, int $y, array $options = null)
+    public function move(float $x, float $y, array $options = null)
     {
         $this->page->assertNotClosed();
 
@@ -329,13 +329,13 @@ class Mouse
     /**
      * Get the maximum distance to scroll a page.
      *
-     * @param int $distance Distance to scroll, positive or negative
-     * @param int $current  Current position
-     * @param int $maximum  Maximum possible distance
+     * @param float $distance Distance to scroll, positive or negative
+     * @param float $current  Current position
+     * @param float $maximum  Maximum possible distance
      *
-     * @return int allowed distance to scroll
+     * @return float allowed distance to scroll
      */
-    private function getMaximumDistance(int $distance, int $current, int $maximum): int
+    private function getMaximumDistance(float $distance, float $current, float $maximum): float
     {
         $result = $current + $distance;
 

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -45,8 +45,8 @@ class Mouse
     }
 
     /**
-     * @param int        $x
-     * @param int        $y
+     * @param float        $x
+     * @param float        $y
      * @param array|null $options
      *
      * @throws \HeadlessChromium\Exception\CommunicationException

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -45,8 +45,8 @@ class Mouse
     }
 
     /**
-     * @param float        $x
-     * @param float        $y
+     * @param float      $x
+     * @param float      $y
      * @param array|null $options
      *
      * @throws \HeadlessChromium\Exception\CommunicationException

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -82,7 +82,7 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         self::assertSame(100, $windowScrollY);
-        self::assertSame(100, $page->mouse()->getPosition()['y']);
+        self::assertSame(100.0, $page->mouse()->getPosition()['y']);
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
@@ -90,7 +90,7 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         self::assertSame(0, $windowScrollY);
-        self::assertSame(0, $page->mouse()->getPosition()['y']);
+        self::assertSame(0.0, $page->mouse()->getPosition()['y']);
 
         // try to scroll more than possible
         $page->mouse()->scrollDown(10000);
@@ -98,7 +98,7 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         self::assertLessThan(10000, $windowScrollY);
-        self::assertLessThan(10000, $page->mouse()->getPosition()['y']);
+        self::assertLessThan(10000.0, $page->mouse()->getPosition()['y']);
     }
 
     /**
@@ -265,10 +265,10 @@ class MouseApiTest extends BaseTestCase
         $x = $page->mouse()->getPosition()['x'];
         $y = $page->mouse()->getPosition()['y'];
 
-        self::assertGreaterThanOrEqual(1, $x); // 8
-        self::assertLessThanOrEqual(51, $x);
+        self::assertGreaterThanOrEqual(1.0, $x); // 8
+        self::assertLessThanOrEqual(51.0, $x);
 
-        self::assertGreaterThanOrEqual(1, $y); // 87
-        self::assertLessThanOrEqual(107, $y);
+        self::assertGreaterThanOrEqual(1.0, $y); // 87
+        self::assertLessThanOrEqual(107.0, $y);
     }
 }


### PR DESCRIPTION
The origin X/Y comes from Page.getLayoutMetrics.cssContentSize ( https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics )  which returns float values like -0.666748046875 , not integers, but the library erroneously treated it like integers, that can cause Mouse()->find(...)->click() to miss-click on very small targets, and with custom error handlers it can also cause
```
["trace":"Exception":private]=>
    array(9) {
      [0]=>
      array(4) {
        ["file"]=>
        string(52) "C:\temp\vendor\chrome-php\chrome\src\Input\Mouse.php"
        ["line"]=>
        int(338)
        ["function"]=>
        string(9) "{closure}"
        ["args"]=>
        array(4) {
          [0]=>
          int(8192)
          [1]=>
          string(69) "Implicit conversion from float -0.666748046875 to int loses precision"
          [2]=>
          string(52) "C:\temp\vendor\chrome-php\chrome\src\Input\Mouse.php"
          [3]=>
          int(338)
        }
      }
```
(and that is exactly what happened to me and how I noticed the problem)