### PR TITLE
fix guessChromeBinaryPath on Ubuntu 24.04

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return \rtrim(\explode("\n", (string) self::shellExec('command -v google-chrome chromium-browser chrome chromium'), 2)[0]) ?: 'chrome';
+                return \rtrim(\explode("\n", (string) self::shellExec('bash -c "command -v google-chrome chromium-browser chrome chromium"'), 2)[0]) ?: 'chrome';
         }
     }
 


### PR DESCRIPTION
This is a strange one:
- On Ubuntu 24.04, shell_exec() does not have access to command
- On Ubuntu 24.04, sh have access to command but it appears bugged, sh -c 'command -v bin1 bin2' will ignore bin2
- To access a 'command -v' that actually check more than the first command, we need to use bash, not sh: bash -c 'command -v bin1 bin2 bin3' will look for all of them.

that sure is a headscratcher...

look at this:
```
$ command -v google-chrome chromium-browser chrome chromium
/usr/bin/chromium-browser
/snap/bin/chromium
$ php -r 'var_dump(shell_exec("command -v google-chrome chromium-browser chrome chromium"));'
NULL
$ php -r 'var_dump(shell_exec("sh -c '\''command -v google-chrome chromium-browser chrome chromium'\''"));'
NULL
$ php -r 'var_dump(shell_exec("sh -c '\''command -v chromium-browser google-chrome chromium-browser chrome chromium'\''"));'
string(26) "/usr/bin/chromium-browser
"
$ php -r 'var_dump(shell_exec("bash -c '\''command -v google-chrome chromium-browser chrome chromium'\''"));'
string(45) "/usr/bin/chromium-browser
/snap/bin/chromium
"
```