### PR TITLE
[1.12] Fix implicitly nullable parameters

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -98,7 +98,7 @@ class Browser
      *
      * @param string|null $script
      */
-    public function setPagePreScript(string $script = null): void
+    public function setPagePreScript(?string $script = null): void
     {
         $this->pagePreScript = $script;
     }

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -78,7 +78,7 @@ class BrowserProcess implements LoggerAwareInterface
      *
      * @param LoggerInterface|null $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         // set or create logger
         $this->setLogger($logger ?? new NullLogger());

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -50,7 +50,7 @@ class BrowserFactory
      */
     protected $options = [];
 
-    public function __construct(string $chromeBinary = null)
+    public function __construct(?string $chromeBinary = null)
     {
         $this->chromeBinary = $chromeBinary ?? (new AutoDiscover())->guessChromeBinaryPath();
     }

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -96,7 +96,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @param SocketInterface|string $socketClient
      * @param int|null               $sendSyncDefaultTimeout
      */
-    public function __construct($socketClient, LoggerInterface $logger = null, int $sendSyncDefaultTimeout = null)
+    public function __construct($socketClient, ?LoggerInterface $logger = null, ?int $sendSyncDefaultTimeout = null)
     {
         // set or create logger
         $this->setLogger($logger ?? new NullLogger());
@@ -264,7 +264,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      *
      * @return Response
      */
-    public function sendMessageSync(Message $message, int $timeout = null): Response
+    public function sendMessageSync(Message $message, ?int $timeout = null): Response
     {
         $responseReader = $this->sendMessage($message);
         $response = $responseReader->waitForResponse($timeout);
@@ -355,7 +355,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      *
      * @internal
      */
-    private function dispatchMessage(string $message, Session $session = null)
+    private function dispatchMessage(string $message, ?Session $session = null)
     {
         // responses come as json string
         $response = \json_decode($message, true);

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -103,7 +103,7 @@ class ResponseReader
      *
      * @return Response
      */
-    public function waitForResponse(int $timeout = null): Response
+    public function waitForResponse(?int $timeout = null): Response
     {
         if ($this->hasResponse()) {
             return $this->getResponse();

--- a/src/Communication/Session.php
+++ b/src/Communication/Session.php
@@ -82,7 +82,7 @@ class Session extends EventEmitter
      *
      * @return Response
      */
-    public function sendMessageSync(Message $message, int $timeout = null): Response
+    public function sendMessageSync(Message $message, ?int $timeout = null): Response
     {
         $responseReader = $this->sendMessage($message);
 

--- a/src/Communication/Socket/Wrench.php
+++ b/src/Communication/Socket/Wrench.php
@@ -44,7 +44,7 @@ class Wrench implements SocketInterface, LoggerAwareInterface
     /**
      * @param WrenchClient $client
      */
-    public function __construct(WrenchClient $client, LoggerInterface $logger = null)
+    public function __construct(WrenchClient $client, ?LoggerInterface $logger = null)
     {
         $this->client = $client;
 

--- a/src/Cookies/CookiesCollection.php
+++ b/src/Cookies/CookiesCollection.php
@@ -21,7 +21,7 @@ class CookiesCollection implements \IteratorAggregate, \Countable
     /**
      * CookiesCollection constructor.
      */
-    public function __construct(array $cookies = null)
+    public function __construct(?array $cookies = null)
     {
         if ($cookies) {
             foreach ($cookies as $cookie) {

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -180,7 +180,7 @@ class Keyboard
      *
      * @return $this
      */
-    public function release(string $key = null): self
+    public function release(?string $key = null): self
     {
         $this->page->assertNotClosed();
 

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -54,7 +54,7 @@ class Mouse
      *
      * @return $this
      */
-    public function move(int $x, int $y, array $options = null)
+    public function move(int $x, int $y, ?array $options = null)
     {
         $this->page->assertNotClosed();
 
@@ -88,7 +88,7 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function press(array $options = null)
+    public function press(?array $options = null)
     {
         $this->page->assertNotClosed();
         $this->page->getSession()->sendMessageSync(new Message('Input.dispatchMouseEvent', [
@@ -106,7 +106,7 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function release(array $options = null)
+    public function release(?array $options = null)
     {
         $this->page->assertNotClosed();
         $this->page->getSession()->sendMessageSync(new Message('Input.dispatchMouseEvent', [
@@ -126,7 +126,7 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function click(array $options = null)
+    public function click(?array $options = null)
     {
         $this->press($options);
         $this->release($options);

--- a/src/Page.php
+++ b/src/Page.php
@@ -532,7 +532,7 @@ class Page
      *
      * @return Clip
      */
-    public function getFullPageClip(int $timeout = null): Clip
+    public function getFullPageClip(?int $timeout = null): Clip
     {
         $contentSize = $this->getLayoutMetrics()->await($timeout)->getCssContentSize();
 
@@ -1013,7 +1013,7 @@ class Page
      *
      * @return CookiesCollection
      */
-    public function getCookies(int $timeout = null)
+    public function getCookies(?int $timeout = null)
     {
         return $this->readCookies()->await($timeout)->getCookies();
     }
@@ -1033,7 +1033,7 @@ class Page
      *
      * @return CookiesCollection
      */
-    public function getAllCookies(int $timeout = null)
+    public function getAllCookies(?int $timeout = null)
     {
         return $this->readAllCookies()->await($timeout)->getCookies();
     }

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -43,7 +43,7 @@ abstract class AbstractBinaryInput
      *
      * @return mixed
      */
-    public function getBase64(int $timeout = null)
+    public function getBase64(?int $timeout = null)
     {
         $response = $this->responseReader->waitForResponse($timeout);
 

--- a/src/PageUtils/PageEvaluation.php
+++ b/src/PageUtils/PageEvaluation.php
@@ -72,7 +72,7 @@ class PageEvaluation
      *
      * @param int|null $timeout
      */
-    public function waitForResponse(int $timeout = null)
+    public function waitForResponse(?int $timeout = null)
     {
         $this->response = $this->responseReader->waitForResponse($timeout);
 
@@ -102,7 +102,7 @@ class PageEvaluation
      *
      * @return mixed
      */
-    public function getReturnValue(int $timeout = null)
+    public function getReturnValue(?int $timeout = null)
     {
         if (!$this->response) {
             $this->waitForResponse($timeout);
@@ -120,7 +120,7 @@ class PageEvaluation
      *
      * @return mixed
      */
-    public function getReturnType(int $timeout = null)
+    public function getReturnType(?int $timeout = null)
     {
         if (!$this->response) {
             $this->waitForResponse($timeout);

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -123,7 +123,7 @@ class PageNavigation
      *
      * @return mixed
      */
-    public function waitForNavigation($eventName = Page::LOAD, int $timeout = null)
+    public function waitForNavigation($eventName = Page::LOAD, ?int $timeout = null)
     {
         if (null === $timeout) {
             $timeout = 30000;

--- a/src/PageUtils/ResponseWaiter.php
+++ b/src/PageUtils/ResponseWaiter.php
@@ -46,7 +46,7 @@ class ResponseWaiter
      *
      * @return $this
      */
-    public function await(int $time = null)
+    public function await(?int $time = null)
     {
         $this->response = $this->responseReader->waitForResponse($time);
 
@@ -68,7 +68,7 @@ class ResponseWaiter
      *
      * @return Response
      */
-    protected function awaitResponse(int $time = null): Response
+    protected function awaitResponse(?int $time = null): Response
     {
         if (!$this->response) {
             $this->await($time);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -53,7 +53,7 @@ class Utils
      *
      * @return mixed
      */
-    public static function tryWithTimeout(int $timeoutMicroSec, \Generator $generator, callable $onTimeout = null)
+    public static function tryWithTimeout(int $timeoutMicroSec, \Generator $generator, ?callable $onTimeout = null)
     {
         $waitUntilMicroSec = \hrtime(true) / 1000 + $timeoutMicroSec;
 


### PR DESCRIPTION
Add ? to all method arguments that are implicitly nullable, because this is deprecated in PHP 8.4:
https://www.php.net/manual/en/migration84.deprecated.php