### PR TITLE
bugfix implicitly nullable parameter in AbstractBinaryInput::getRawBinary()

### DIFF
--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -63,7 +63,7 @@ abstract class AbstractBinaryInput
      *
      * @return string
      */
-    public function getRawBinary(int $timeout = null): string
+    public function getRawBinary(?int $timeout = null): string
     {
         return \base64_decode($this->getBase64($timeout), true);
     }


### PR DESCRIPTION
possibly overlooked in PR #660 