### PR TITLE
[1.13] Allow setting cookie `session=false`

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -1086,6 +1086,12 @@ class Page
                 $browserCookie['domain'] = \parse_url($this->getCurrentUrl(), \PHP_URL_HOST);
             }
 
+            // convinience wrapper for session=false
+            // DevTools Protocol does not allow setting session=false directly, but it will be set to false if expires is set
+            if (!isset($cookie['expires']) && ($cookie['session'] ?? null) === false) {
+                $browserCookie['expires'] = time() + (1 * 60 * 60 * 24 * 365); // the max expire chromium allows, 365 days, tested on chromium 131.0.6778.139
+            }
+
             $browserCookies[] = $browserCookie;
         }
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -1089,7 +1089,7 @@ class Page
             // convinience wrapper for session=false
             // DevTools Protocol does not allow setting session=false directly, but it will be set to false if expires is set
             if (!isset($cookie['expires']) && ($cookie['session'] ?? null) === false) {
-                $browserCookie['expires'] = time() + (1 * 60 * 60 * 24 * 365); // the max expire chromium allows, 365 days, tested on chromium 131.0.6778.139
+                $browserCookie['expires'] = \time() + (1 * 60 * 60 * 24 * 365); // the max expire chromium allows, 365 days, tested on chromium 131.0.6778.139
             }
 
             $browserCookies[] = $browserCookie;

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -63,7 +63,7 @@ abstract class AbstractBinaryInput
      *
      * @return string
      */
-    public function getRawBinary(int $timeout = null): string
+    public function getRawBinary(?int $timeout = null): string
     {
         return \base64_decode($this->getBase64($timeout), true);
     }


### PR DESCRIPTION
Previously
```php
$page->setCookies([
    \HeadlessChromium\Cookies\Cookie::create("session_false", "session_false", ["session" => false, "domain" => "example.com"]),
    \HeadlessChromium\Cookies\Cookie::create("session_true", "session_true", ["session" => true, "domain" => "example.com"]),
])->await();
```
would create 2 cookies with session=true, but now it will create 1 cookie with session=false and 1 with session=true

close GH-675