### PR TITLE
[1.15] Fix scrolling timeout issue

### DIFF
--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -203,7 +203,7 @@ class Mouse
                 throw $exception;
             }
 
-            if ($distanceY !== 0 || $distanceX !== 0) { // Try with the new values.
+            if (0 !== $distanceY || 0 !== $distanceX) { // Try with the new values.
                 $this->sendScrollMessage($distances);
 
                 // wait until the scroll is done

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -224,7 +224,7 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException\ResponseHasError
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      *
-     * @return array{ distances: array{ x: int, y: int }, targets: array{ x: int, y: int } }
+     * @return array{ array{ x: int, y: int }, array{ x: int, y: int } }
      */
     private function getScrollDistancesAndTargets(int $distanceY, int $distanceX = 0): array
     {
@@ -242,7 +242,7 @@ class Mouse
 
         return [
             ['x' => $distanceX, 'y' => $distanceY],
-            ['x' => $targetX, 'y' => $targetY],
+            ['x' => (int) $targetX, 'y' => (int) $targetY],
         ];
     }
 


### PR DESCRIPTION
This change addresses an issue where the maximum scrolling distance may change between calculating it, sending the scroll message, and verifying the new position. If verifying the position times out, the code now checks if the scrolling distance has changed. If it has, scrolling is retried once.

I encountered this issue on pages where an overlay pops up. The problem occurs randomly, approximately once every 10 executions of the same code. I suspect it happens when the overlay is rendered precisely between calculating the maximum possible scroll distance and verifying it after sending the scroll message.

This change appears to have completely resolved the issue in my specific case. However, I haven’t added a test case, as I don't know how to reliably reproduce this behavior.

I also reduced the wait time for verifying the new position, as 30 seconds seemed unnecessarily long.

I created this pull request directly without opening an issue first. If you’d prefer that I create an issue as well, please let me know.