### PR TITLE
[1.15] Fix Linux Chrome binary detection on POSIX shells

### DIFF
--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -40,7 +40,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return \rtrim(\explode("\n", (string) self::shellExec('command -v google-chrome chromium-browser chrome chromium'), 2)[0]) ?: 'chrome';
+                return \rtrim(\explode("\n", (string) self::shellExec('command -v google-chrome || command -v chromium-browser || command -v chrome || command -v chromium'), 2)[0]) ?: 'chrome';
         }
     }
 


### PR DESCRIPTION
Some Linux distributions use dash as the default sh, but in "dash", "command -v" only supports a single argument.