### PR TITLE
[1.14] Security fix for missing encoding in `CssSelector`

### DIFF
--- a/src/Dom/Selector/CssSelector.php
+++ b/src/Dom/Selector/CssSelector.php
@@ -10,40 +10,31 @@ namespace HeadlessChromium\Dom\Selector;
 final class CssSelector implements Selector
 {
     /** @var string */
-    private $expression;
+    private $expressionEncoded;
 
     public function __construct(string $expression)
     {
-        $this->expression = $expression;
-    }
-
-    public function expressionCount(): string
-    {
-        $encodedExpr = \json_encode(
-            $this->expression,
+        $this->expressionEncoded = \json_encode(
+            $expression,
             \JSON_UNESCAPED_SLASHES
                 | \JSON_UNESCAPED_UNICODE
                 | \JSON_THROW_ON_ERROR
         );
+    }
 
+    public function expressionCount(): string
+    {
         return \sprintf(
             'document.querySelectorAll(%s).length',
-            $encodedExpr
+            $this->expressionEncoded
         );
     }
 
     public function expressionFindOne(int $position): string
     {
-        $encodedExpr = \json_encode(
-            $this->expression,
-            \JSON_UNESCAPED_SLASHES
-                | \JSON_UNESCAPED_UNICODE
-                | \JSON_THROW_ON_ERROR
-        );
-
         return \sprintf(
             'document.querySelectorAll(%s)[%d]',
-            $encodedExpr,
+            $this->expressionEncoded,
             $position - 1
         );
     }

--- a/src/Dom/Selector/CssSelector.php
+++ b/src/Dom/Selector/CssSelector.php
@@ -19,11 +19,32 @@ final class CssSelector implements Selector
 
     public function expressionCount(): string
     {
-        return \sprintf('document.querySelectorAll("%s").length', $this->expression);
+        $encodedExpr = \json_encode(
+            $this->expression,
+            \JSON_UNESCAPED_SLASHES
+                | \JSON_UNESCAPED_UNICODE
+                | \JSON_THROW_ON_ERROR
+        );
+
+        return \sprintf(
+            'document.querySelectorAll(%s).length',
+            $encodedExpr
+        );
     }
 
     public function expressionFindOne(int $position): string
     {
-        return \sprintf('document.querySelectorAll("%s")[%d]', $this->expression, $position - 1);
+        $encodedExpr = \json_encode(
+            $this->expression,
+            \JSON_UNESCAPED_SLASHES
+                | \JSON_UNESCAPED_UNICODE
+                | \JSON_THROW_ON_ERROR
+        );
+
+        return \sprintf(
+            'document.querySelectorAll(%s)[%d]',
+            $encodedExpr,
+            $position - 1
+        );
     }
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -445,9 +445,9 @@ class PageTest extends BaseTestCase
         $page->waitUntilContainsElement('div[data-name=el]'); // search for <div data-name="el">
         $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
-        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, strtr($page->getHtml(), [
-            '&quot;' => '"',
-        ]));
+        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, \strtr($page->getHtml(), [
+             '&quot;' => '"',
+         ]));
     }
 
     public function testWaitUntilContainsElementByXPath(): void

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -21,7 +21,7 @@ use HeadlessChromium\Exception\InvalidTimezoneId;
  */
 class PageTest extends BaseTestCase
 {
-    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content</div>';
+    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content</div><div data-name="&quot;el&quot;"></div>';
     private const WAIT_FOR_ELEMENT_RESOURCE_FILE = 'elementLoad.html';
 
     public function testSetViewport(): void
@@ -441,7 +441,9 @@ class PageTest extends BaseTestCase
 
         self::assertStringNotContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
 
-        $page->waitUntilContainsElement('div[data-name=\"el\"]');
+        $page->waitUntilContainsElement('div[data-name="el"]'); // search for <div data-name="el">
+        $page->waitUntilContainsElement('div[data-name=el]'); // search for <div data-name="el">
+        $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
         self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
     }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -445,9 +445,7 @@ class PageTest extends BaseTestCase
         $page->waitUntilContainsElement('div[data-name=el]'); // search for <div data-name="el">
         $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
-        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, \strtr($page->getHtml(), [
-            '&quot;' => '"',
-        ]));
+        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
     }
 
     public function testWaitUntilContainsElementByXPath(): void

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -446,8 +446,8 @@ class PageTest extends BaseTestCase
         $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
         self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, \strtr($page->getHtml(), [
-             '&quot;' => '"',
-         ]));
+            '&quot;' => '"',
+        ]));
     }
 
     public function testWaitUntilContainsElementByXPath(): void

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -21,7 +21,7 @@ use HeadlessChromium\Exception\InvalidTimezoneId;
  */
 class PageTest extends BaseTestCase
 {
-    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content</div><div data-name="&quot;el&quot;"></div>';
+    private const WAIT_FOR_ELEMENT_HTML = '<div data-name="el">content1</div><div data-name="&quot;el&quot;">content2</div>';
     private const WAIT_FOR_ELEMENT_RESOURCE_FILE = 'elementLoad.html';
 
     public function testSetViewport(): void
@@ -445,7 +445,9 @@ class PageTest extends BaseTestCase
         $page->waitUntilContainsElement('div[data-name=el]'); // search for <div data-name="el">
         $page->waitUntilContainsElement('div[data-name=\"el\"]'); // search for <div data-name="&quot;el&quot;'>
 
-        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, $page->getHtml());
+        self::assertStringContainsString(self::WAIT_FOR_ELEMENT_HTML, strtr($page->getHtml(), [
+            '&quot;' => '"',
+        ]));
     }
 
     public function testWaitUntilContainsElementByXPath(): void

--- a/tests/resources/static-web/elementLoad.html
+++ b/tests/resources/static-web/elementLoad.html
@@ -11,14 +11,14 @@
       let el = document.createElement('div');
 
       el.dataset.name = 'el';
-      el.innerHTML = 'content';
+      el.innerHTML = 'content1';
 
       document.body.appendChild(el)
 
       let el2 = document.createElement('div');
 
       el2.dataset.name = '"el"';
-      el2.innerHTML = 'content';
+      el2.innerHTML = 'content2';
       document.body.appendChild(el2)
     }, 500)
 </script>

--- a/tests/resources/static-web/elementLoad.html
+++ b/tests/resources/static-web/elementLoad.html
@@ -14,6 +14,12 @@
       el.innerHTML = 'content';
 
       document.body.appendChild(el)
+
+      let el2 = document.createElement('div');
+
+      el2.dataset.name = '"el"';
+      el2.innerHTML = 'content';
+      document.body.appendChild(el2)
     }, 500)
 </script>
 </html>


### PR DESCRIPTION
CSS Selector expressions are not properly encoded, for example `input[type="password"]`
is a perfectly valid CSS selector, and
```php
$page->mouse()->find('input[type="password"]')
```
should have worked, but it generate a javascript syntax error at runtime:
```js
document.querySelectorAll("input[type="password"]").length
```
resulting in

> PHP Fatal error:  Uncaught HeadlessChromium\Exception\ElementNotFoundException: The search for "document.querySelectorAll("input[type="password"]").length" returned no result. in /home/hans/projects/tryparrotai-unofficial-api/vendor/chrome-php/chrome/src/Input/Mouse.php:302 Stack trace:
> #0 /home/hans/projects/tryparrotai-unofficial-api/vendor/chrome-php/chrome/src/Input/Mouse.php(269): HeadlessChromium\Input\Mouse->findElement()
> 

This is the same issue as in https://github.com/chrome-php/chrome/pull/576