### PR TITLE
add json error message

### DIFF
--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -379,7 +379,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         $jsonErrorId = \json_last_error();
         if (\JSON_ERROR_NONE !== $jsonErrorId) {
             if ($this->isStrict()) {
-                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %d: %s', $jsonErrorId, json_last_error_msg());
+                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %d: %s', $jsonErrorId, json_last_error_msg()));
             }
 
             return false;

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -376,10 +376,10 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         $response = \json_decode($message, true);
 
         // if json not valid throw exception
-        $jsonError = \json_last_error();
-        if (\JSON_ERROR_NONE !== $jsonError) {
+        $jsonErrorId = \json_last_error();
+        if (\JSON_ERROR_NONE !== $jsonErrorId) {
             if ($this->isStrict()) {
-                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %s', $jsonError));
+                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %d: %s', $jsonErrorId, json_last_error_msg());
             }
 
             return false;

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -379,7 +379,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         $jsonErrorId = \json_last_error();
         if (\JSON_ERROR_NONE !== $jsonErrorId) {
             if ($this->isStrict()) {
-                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %d: %s', $jsonErrorId, json_last_error_msg()));
+                throw new CannotReadResponse(\sprintf('Response from chrome remote interface is not a valid json response. JSON error: %d: %s', $jsonErrorId, \json_last_error_msg()));
             }
 
             return false;


### PR DESCRIPTION
while looking into https://github.com/chrome-php/chrome/issues/666 i got
> PHP Fatal error:  Uncaught HeadlessChromium\Exception\CommunicationException\CannotReadResponse: Response from chrome remote interface is not a valid json response. JSON error: 10 in /home/hans/projects/misc/vendor/chrome-php/chrome/src/Communication/Connection.php:382

But the message string may contain more valuable data, such as

>Single unpaired UTF-16 surrogate in unicode escape

There is not a specific json error id for "unpaired UTF-16 surrogate",
thus that information was lost prior to this patch.