### PR TITLE
[1.14] Fix missing `$socketFile` variable in Persistent Browser example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,10 @@ The next calls to the script will read the uri from that file in order to connec
 use \HeadlessChromium\BrowserFactory;
 use \HeadlessChromium\Exception\BrowserConnectionFailed;
 
+$socketFile = '/tmp/chrome-php-demo-socket';
+
 // path to the file to store websocket's uri
-$socket = \file_get_contents('/tmp/chrome-php-demo-socket');
+$socket = \file_get_contents($socketFile);
 
 try {
     $browser = BrowserFactory::connectToBrowser($socket);


### PR DESCRIPTION
The current example script references a `$socketFile` variable that does't exist:

https://github.com/chrome-php/chrome/blob/9dce1e484a6703e487da5e219d39a8d2fb3d8afa/README.md?plain=1#L193-L212