### PR TITLE
PageNavigation was marked as internal, but is heavely used externally.

### DIFF
--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -22,8 +22,6 @@ use HeadlessChromium\Utils;
 
 /**
  * A class that is aimed to be used withing the method Page::navigate.
- *
- * @internal
  */
 class PageNavigation
 {


### PR DESCRIPTION
Promotes PageNavigation to the public API. The class is already widely used in the ecosystem and referred in the documentation, making the @internal flag obsolete and misleading. This change formalizes its status as a supported component of the library.