### PR TITLE
Allow choosing the box model in `Node::getPosition()` method

### DIFF
--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -128,7 +128,10 @@ class Node
         return $this->getAttributes()->get($name);
     }
 
-    public function getPosition(): ?NodePosition
+    /**
+     * @param 'content'|'padding'|'border'|'margin' $boxModel
+     */
+    public function getPosition(string $boxModel = 'content'): ?NodePosition
     {
         $message = new Message('DOM.getBoxModel', [
             'nodeId' => $this->getNodeIdForRequest(),
@@ -137,7 +140,7 @@ class Node
 
         $this->assertNotError($response);
 
-        $points = $response->getResultData('model')['content'];
+        $points = $response->getResultData('model')[$boxModel] ?? null;
 
         if (null !== $points) {
             return new NodePosition($points);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -5,6 +5,7 @@ namespace HeadlessChromium\Test;
 use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Exception\StaleElementException;
+use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @covers \HeadlessChromium\Dom\Dom
@@ -24,14 +25,6 @@ class DomTest extends BaseTestCase
     {
         parent::tearDownAfterClass();
         self::$browser->close();
-    }
-
-    private function openSitePage($file)
-    {
-        $page = self::$browser->createPage();
-        $page->navigate(self::sitePath($file))->waitForNavigation();
-
-        return $page;
     }
 
     public function testSearchByCssSelector(): void
@@ -140,6 +133,45 @@ class DomTest extends BaseTestCase
         self::assertSame('hello', $value);
     }
 
+    #[TestWith(['margin', 0, 0, 310, 360])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['border', 20, 10, 270, 340])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['padding', 25, 15, 260, 330])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['content', 55, 30, 200, 300])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith([null, 55, 30, 200, 300])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['-invalid-', 0, 0, 0, 0])]
+    public function testGetPosition(
+        ?string $boxModel,
+        float $expectedX,
+        float $expectedY,
+        float $expectedWidth,
+        float $expectedHeight,
+    ): void {
+        $page = $this->openSitePage('boxModel.html');
+
+        $element = $page->dom()->querySelector('#elem');
+
+        if (null !== $boxModel) {
+            $position = $element->getPosition($boxModel);
+        } else {
+            $position = $element->getPosition();
+        }
+
+        if ('-invalid-' !== $boxModel) {
+            self::assertNotNull($position);
+            self::assertSame($expectedX, $position->getX());
+            self::assertSame($expectedY, $position->getY());
+            self::assertSame($expectedWidth, $position->getWidth());
+            self::assertSame($expectedHeight, $position->getHeight());
+        } else {
+            self::assertNull($position);
+        }
+    }
+
     public function testUploadFile(): void
     {
         $page = $this->openSitePage('domForm.html');
@@ -239,5 +271,13 @@ class DomTest extends BaseTestCase
         $this->expectException(StaleElementException::class);
 
         $inputNode->sendKeys('test');
+    }
+
+    private function openSitePage($file)
+    {
+        $page = self::$browser->createPage();
+        $page->navigate(self::sitePath($file))->waitForNavigation();
+
+        return $page;
     }
 }

--- a/tests/resources/static-web/boxModel.html
+++ b/tests/resources/static-web/boxModel.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <title>box model - test</title>
+
+    <style>
+        html, body{
+            width: 500px;
+            height: 500px;
+            margin: 0;
+            padding: 0;
+        }
+
+        div {
+            width: 200px;
+            height: 300px;
+            margin: 10px 20px;
+            padding: 15px 30px;
+            border: 5px solid red;
+        }
+    </style>
+</head>
+<body>
+<div id="elem">
+    some content
+</div>
+</body>
+</html>

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "phpstan/phpstan": "2.1.3"
     },
     "config": {


### PR DESCRIPTION
When rendering single page documents, this method would be so handy, but it only measures the content-box, so the element padding is omitted.

For this task, and potentially other tasks, it would be useful to be able to chose the box model.

Default to `content`, so it is backwards compatible!

PD: Ideally, a `getBoxModel` method could be added, deprecating the `getPosition`, and return measures for every box model the devtools API returns.