### PR TITLE
[1.16] Add `Page::authenticate` to fix proxy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,21 @@ if ($cookieBar) {
 }
 ```
 
+### HTTP Authentication
+
+You can set credentials for HTTP Basic Authentication using `Page::authenticate` before navigating to a protected page or when using a proxy. If the credentials are invalid, an `AuthenticationFailed` exception is thrown.
+
+```php
+use HeadlessChromium\Exception\AuthenticationFailed;
+
+try {
+    $page->authenticate('username', 'password');
+    $page->navigate('http://example.com/protected')->waitForNavigation();
+} catch (AuthenticationFailed $e) {
+    // invalid credentials
+}
+```
+
 ### Set user agent
 
 You can set up a user-agent per page:

--- a/src/Exception/AuthenticationFailed.php
+++ b/src/Exception/AuthenticationFailed.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Exception;
+
+class AuthenticationFailed extends \Exception
+{
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -20,6 +20,7 @@ use HeadlessChromium\Dom\Dom;
 use HeadlessChromium\Dom\Node;
 use HeadlessChromium\Dom\Selector\CssSelector;
 use HeadlessChromium\Dom\Selector\Selector;
+use HeadlessChromium\Exception\AuthenticationFailed;
 use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\EvaluationFailed;
 use HeadlessChromium\Exception\InvalidTimezoneId;
@@ -156,6 +157,64 @@ class Page
         $this->assertNotClosed();
 
         return $this->target->getSession();
+    }
+
+    /**
+     * Sets credentials to be used when the page encounters an HTTP authentication challenge.
+     *
+     * @throws AuthenticationFailed
+     * @throws CommunicationException
+     */
+    public function authenticate(string $username, string $password): void
+    {
+        $this->assertNotClosed();
+
+        $credentialsAttempted = false;
+
+        $this->getSession()->on('method:Fetch.authRequired', function (array $params) use ($username, $password, &$credentialsAttempted) {
+            if ($credentialsAttempted) {
+                $this->getSession()->sendMessageSync(
+                    new Message('Fetch.continueWithAuth', [
+                        'requestId' => $params['requestId'],
+                        'authChallengeResponse' => [
+                            'response' => 'CancelAuth',
+                        ],
+                    ])
+                );
+
+                throw new AuthenticationFailed('Authentication failed: invalid credentials.');
+            }
+
+            $credentialsAttempted = true;
+
+            $this->getSession()->sendMessageSync(
+                new Message('Fetch.continueWithAuth', [
+                    'requestId' => $params['requestId'],
+                    'authChallengeResponse' => [
+                        'response' => 'ProvideCredentials',
+                        'username' => $username,
+                        'password' => $password,
+                    ],
+                ])
+            );
+        });
+
+        $this->getSession()->on('method:Fetch.requestPaused', function (array $params) {
+            $this->getSession()->sendMessageSync(
+                new Message('Fetch.continueRequest', [
+                    'requestId' => $params['requestId'],
+                ])
+            );
+        });
+
+        $this->getSession()->sendMessageSync(
+            new Message('Fetch.enable', [
+                'handleAuthRequests' => true,
+                'patterns' => [
+                    ['urlPattern' => '*'],
+                ],
+            ])
+        );
     }
 
     /**

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Exception\AuthenticationFailed;
+
+/**
+ * @covers \HeadlessChromium\Page::authenticate
+ */
+class AuthenticationTest extends HttpEnabledTestCase
+{
+    private const AUTH_URL = 'basic-auth.php';
+    private const VALID_USER = 'testuser';
+    private const VALID_PASS = 'testpass';
+
+    public function testAuthenticateAllowsAccessWithValidCredentials(): void
+    {
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS);
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        // let's hit it twice to ensure subsequent requests also work
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+    }
+
+    public function testAuthenticateThrowsOnInvalidCredentials(): void
+    {
+        $this->expectException(AuthenticationFailed::class);
+
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->authenticate('wrong', 'credentials');
+
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+    }
+
+    public function testAuthenticateWithoutCredentialsDeniesAccess(): void
+    {
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringNotContainsString('Authenticated', $page->getHtml());
+    }
+}

--- a/tests/resources/static-web/basic-auth.php
+++ b/tests/resources/static-web/basic-auth.php
@@ -1,0 +1,16 @@
+<?php
+
+$expectedUser = 'testuser';
+$expectedPass = 'testpass';
+
+$user = $_SERVER['PHP_AUTH_USER'] ?? null;
+$pass = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+if ($user !== $expectedUser || $pass !== $expectedPass) {
+    \header('WWW-Authenticate: Basic realm="Test"');
+    \http_response_code(401);
+    echo 'Unauthorized';
+    exit;
+}
+
+echo 'Authenticated';


### PR DESCRIPTION
`Page::setBasicAuthHeader` already exists, but many proxies ignore both  `Authorization` and `Proxy-Authorization` headers and strictly require a challenge-response flow.

This new `Page::authenticate` sends credentials with `Fetch.continueWithAuth` when `Fetch.authRequired` is received. A `CancelAuth` response is used after a failed attempt and an exception is thrown. This should work with any kind of browser auth, not only for proxies.

Resolves #634, #437, #158, #29