### PR TITLE
[1.16] Add `AbstractBinaryInput::saveToStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,11 @@ header('Expires: 0');
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Pragma: public');
 
-echo base64_decode($pdf->getBase64());
+$outputStream = \fopen('php://output', 'w');
+
+$pdf->saveToStream($outputStream);
+
+\fclose($outputStream);
 ```
 
 Options `headerTemplate` and `footerTemplate`:

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -114,7 +114,7 @@ abstract class AbstractBinaryInput
      * Save data to the given stream.
      *
      * @param resource|null $stream If not provided, a php://temp is opened
-     * @param int|null      $timeout
+     * @param int           $timeout
      *
      * @throws FilesystemException
      *

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -111,6 +111,46 @@ abstract class AbstractBinaryInput
     }
 
     /**
+     * Save data to the given stream.
+     *
+     * @param resource|null $stream If not provided, a php://temp is opened
+     * @param int|null      $timeout
+     *
+     * @throws FilesystemException
+     *
+     * @return resource
+     */
+    public function saveToStream($stream = null, int $timeout = 5000)
+    {
+        $response = $this->responseReader->waitForResponse($timeout);
+
+        if (!$response->isSuccessful()) {
+            throw $this->getException($response->getErrorMessage());
+        }
+
+        $ownStream = $stream === null;
+
+        if ($ownStream) {
+            $stream = \fopen('php://temp', 'r+');
+
+            if ($stream === false) {
+                throw new FilesystemException('Could not open a temporary stream.');
+            }
+        }
+
+        $filter = \stream_filter_append($stream, 'convert.base64-decode', STREAM_FILTER_WRITE);
+        \fwrite($stream, $response->getResultData('data'));
+        \stream_filter_remove($filter);
+        \fflush($stream);
+
+        if ($ownStream) {
+            \rewind($stream);
+        }
+
+        return $stream;
+    }
+
+    /**
      * @internal
      *
      * @return \Exception

--- a/tests/PagePdfForTests.php
+++ b/tests/PagePdfForTests.php
@@ -18,4 +18,12 @@ class PagePdfForTests extends PagePdf
     public function __construct()
     {
     }
+
+    /**
+     * @param \HeadlessChromium\Communication\ResponseReader $responseReader
+     */
+    public function setResponseReader($responseReader): void
+    {
+        $this->responseReader = $responseReader;
+    }
 }

--- a/tests/PagePdfTest.php
+++ b/tests/PagePdfTest.php
@@ -11,6 +11,8 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Communication\Response;
+use HeadlessChromium\Communication\ResponseReader;
 use HeadlessChromium\PageUtils\PagePdf;
 
 /**
@@ -94,6 +96,33 @@ class PagePdfTest extends BaseTestCase
         self::assertInstanceOf(PagePdf::class, $this->pagePdf->setOptions([$optionName => $optionValue]));
     }
 
+    public function testSaveToStreamReturnsDecodedContent(): void
+    {
+        $content = 'Test';
+        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+
+        $stream = $pagePdf->saveToStream();
+
+        self::assertIsResource($stream);
+        self::assertSame($content, \stream_get_contents($stream));
+
+        \fclose($stream);
+    }
+
+    public function testSaveToStreamUsesProvidedStream(): void
+    {
+        $content = 'Test';
+        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+
+        $stream = \fopen('php://temp', 'r+');
+        $pagePdf->saveToStream($stream);
+
+        \rewind($stream);
+        self::assertSame($content, \stream_get_contents($stream));
+
+        \fclose($stream);
+    }
+
     private static function getOptionsDataset(string $optionName, array $optionValues): array
     {
         return \array_reduce(
@@ -105,5 +134,20 @@ class PagePdfTest extends BaseTestCase
             },
             []
         );
+    }
+
+    private function createPagePdfWithResponse(string $base64Data): PagePdfForTests
+    {
+        $response = $this->createMock(Response::class);
+        $response->method('isSuccessful')->willReturn(true);
+        $response->method('getResultData')->with('data')->willReturn($base64Data);
+
+        $responseReader = $this->createMock(ResponseReader::class);
+        $responseReader->method('waitForResponse')->willReturn($response);
+
+        $pagePdf = new PagePdfForTests();
+        $pagePdf->setResponseReader($responseReader);
+
+        return $pagePdf;
     }
 }


### PR DESCRIPTION
Similar to `AbstractBinaryInput::saveToFile`, but with a stream. Can be used to pass large PDFs directly to `php://output` without allocating the whole file in memory.

Resolves #495