### PR TITLE
[1.16] Promote PageUtils classes to the public API

### DIFF
--- a/src/PageUtils/CookiesGetter.php
+++ b/src/PageUtils/CookiesGetter.php
@@ -13,9 +13,6 @@ namespace HeadlessChromium\PageUtils;
 
 use HeadlessChromium\Cookies\CookiesCollection;
 
-/**
- * @internal
- */
 class CookiesGetter extends ResponseWaiter
 {
     /**

--- a/src/PageUtils/PageEvaluation.php
+++ b/src/PageUtils/PageEvaluation.php
@@ -19,8 +19,6 @@ use HeadlessChromium\Page;
 
 /**
  * Used to read data from page evaluation response.
- *
- * @internal
  */
 class PageEvaluation
 {

--- a/src/PageUtils/PageLayoutMetrics.php
+++ b/src/PageUtils/PageLayoutMetrics.php
@@ -15,8 +15,6 @@ use HeadlessChromium\Exception\CommunicationException;
 
 /**
  * Used to read layout metrics of the page.
- *
- * @internal
  */
 class PageLayoutMetrics extends ResponseWaiter
 {

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -22,8 +22,6 @@ use HeadlessChromium\Utils;
 
 /**
  * A class that is aimed to be used withing the method Page::navigate.
- *
- * @internal
  */
 class PageNavigation
 {
@@ -74,6 +72,8 @@ class PageNavigation
      * @throws Exception\CommunicationException
      * @throws Exception\CommunicationException\CannotReadResponse
      * @throws Exception\CommunicationException\InvalidResponse
+     *
+     * @internal
      */
     public function __construct(Page $page, string $url, bool $strict = false)
     {


### PR DESCRIPTION
This replaces #721 with a fix covering the whole `PageUtils` family. The class-level `@internal` annotation on `PageNavigation` contradicts the documented API: the class is the return type of the public `Page::navigate()` method and the README demonstrates calling `waitForNavigation()` on it throughout, so static analysers flag every documented usage in downstream projects. The same applies to `PageEvaluation`, `CookiesGetter` and `PageLayoutMetrics`, which are likewise returned by public `Page` methods, while `PageScreenshot`, `PagePdf` and `AbstractBinaryInput` already follow the convention of marking only their internal members. This change removes the class-level annotations from the remaining four classes and marks `PageNavigation`'s constructor as `@internal` instead, matching the existing annotation on `PageEvaluation`'s constructor, since these objects are produced by `Page` and are not meant to be constructed directly.