### PR TITLE
[1.16] Add disableJavascript option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 1.16.0 (UPCOMING)
+
+* Add `disableJavascript` option
+
+
 ## 1.15.0 (2025-12-27)
 
 * Add PHP 8.5 support

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Here are the options available for the browser factory:
 | `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                       |
 | `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`          |
 | `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages       |
+| `disableJavascript`       | `false` | Disable JavaScript execution on every page created by the browser                                  |
 | `disableNotifications`    | `false` | Disable browser notifications                                                                      |
 | `enableImages`            | `true`  | Toggles loading of images                                                                          |
 | `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)                |

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Here are the options available for the browser factory:
 | `connectionDelay`         | `0`     | Delay to apply between each operation for debugging purposes                                       |
 | `customFlags`             | none    | An array of flags to pass to the command line. Eg: `['--option1', '--option2=someValue']`          |
 | `debugLogger`             | `null`  | A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages       |
-| `disableJavascript`       | `false` | Disable JavaScript execution on every page created by the browser                                  |
+| `disableJavascript`       | `false` | Disable JavaScript execution on every page created via `createPage()`                              |
 | `disableNotifications`    | `false` | Disable browser notifications                                                                      |
 | `enableImages`            | `true`  | Toggles loading of images                                                                          |
 | `envVariables`            | none    | An array of environment variables to pass to the process (example DISPLAY variable)                |

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -43,6 +43,13 @@ class Browser
      */
     protected $pagePreScript;
 
+    /**
+     * Whether JavaScript execution must be disabled on every new page.
+     *
+     * @var bool
+     */
+    protected $pageScriptExecutionDisabled = false;
+
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
@@ -101,6 +108,14 @@ class Browser
     public function setPagePreScript(?string $script = null): void
     {
         $this->pagePreScript = $script;
+    }
+
+    /**
+     * Disable or enable JavaScript execution for every new page created by this browser.
+     */
+    public function setPageScriptExecutionDisabled(bool $disabled = true): void
+    {
+        $this->pageScriptExecutionDisabled = $disabled;
     }
 
     /**
@@ -256,6 +271,11 @@ class Browser
         // add prescript
         if ($this->pagePreScript) {
             $page->addPreScript($this->pagePreScript);
+        }
+
+        // disable javascript execution if requested at the browser level
+        if ($this->pageScriptExecutionDisabled) {
+            $page->setScriptExecution(false)->await();
         }
 
         $this->pages[$targetId] = $page;

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -159,6 +159,11 @@ class BrowserProcess implements LoggerAwareInterface
 
         // create browser instance
         $this->browser = new ProcessAwareBrowser($connection, $this);
+
+        // disable javascript execution for new pages if requested
+        if (\array_key_exists('disableJavascript', $options) && (true === $options['disableJavascript'])) {
+            $this->browser->setPageScriptExecutionDisabled(true);
+        }
     }
 
     /**

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -31,6 +31,7 @@ class BrowserFactory
      * - connectionDelay: Delay to apply between each operation for debugging purposes (default: none)
      * - customFlags: An array of flags to pass to the command line.
      * - debugLogger: A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages (default: none)
+     * - disableJavascript: Disable JavaScript execution on every page created by the browser (default: false)
      * - disableNotifications: Disable browser notifications (default: false)
      * - enableImages: Toggles loading of images (default: true)
      * - envVariables: An array of environment variables to pass to the process (example DISPLAY variable)

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -31,7 +31,7 @@ class BrowserFactory
      * - connectionDelay: Delay to apply between each operation for debugging purposes (default: none)
      * - customFlags: An array of flags to pass to the command line.
      * - debugLogger: A string (e.g "php://stdout"), or resource, or PSR-3 logger instance to print debug messages (default: none)
-     * - disableJavascript: Disable JavaScript execution on every page created by the browser (default: false)
+     * - disableJavascript: Disable JavaScript execution on every page created via createPage() (default: false)
      * - disableNotifications: Disable browser notifications (default: false)
      * - enableImages: Toggles loading of images (default: true)
      * - envVariables: An array of environment variables to pass to the process (example DISPLAY variable)

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -15,6 +15,7 @@ use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Communication\Target;
 
 /**
+ * @covers \HeadlessChromium\Browser
  * @covers \HeadlessChromium\BrowserFactory
  * @covers \HeadlessChromium\Browser\BrowserProcess
  */

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -111,6 +111,38 @@ class BrowserFactoryTest extends BaseTestCase
         self::assertSame([], $factory->getOptions());
     }
 
+    public function testDisableJavascriptOption(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser([
+            'disableJavascript' => true,
+        ]);
+
+        $page = $browser->createPage();
+        $page->navigate(self::sitePath('javascript.html'))->waitForNavigation();
+
+        self::assertSame(
+            'javascript disabled',
+            $page->evaluate('document.body.innerText')->getReturnValue()
+        );
+    }
+
+    public function testDisableJavascriptOptionDefault(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+
+        $page = $browser->createPage();
+        $page->navigate(self::sitePath('javascript.html'))->waitForNavigation();
+
+        self::assertSame(
+            'javascript enabled',
+            $page->evaluate('document.body.innerText')->getReturnValue()
+        );
+    }
+
     public function testConnectToBrowser(): void
     {
         // create a browser


### PR DESCRIPTION
This supersedes #723, retargeted at `1.16` since it is a new feature and `1.15` has already been released. It cherry-picks @Pablo1Gustavo's commits adding a `disableJavascript` browser factory option that disables JavaScript execution on every page the browser creates, reading the option with the same convention as `disableNotifications` and propagating it to new pages in `Browser::getPage()` the same way as the existing `pagePreScript`, via `Emulation.setScriptExecutionDisabled`. A follow-up commit adds the missing `1.16.0` changelog entry, clarifies in the README and the options docblock that the option applies to pages created via `createPage()` (pages opened by web content themselves are only covered once they are materialised through the browser API, by which time their scripts may already have run), and adds the missing `@covers` annotation for `Browser`, where the new page hook lives, to the factory test.