### PR TITLE
[1.15] Fix scroll timeouts when the page changes mid-scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 1.15.1 (UPCOMING)
+
+* Fixed mouse scrolling timing out when the page changes during the scroll
+
+
 ## 1.15.0 (2025-12-27)
 
 * Add PHP 8.5 support

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -26,6 +26,11 @@ class Mouse
     public const BUTTON_RIGHT = 'right';
     public const BUTTON_MIDDLE = 'middle';
 
+    private const SCROLL_TIMEOUT = 10_000_000;
+    private const SCROLL_POLL_INTERVAL = 16_000; // one frame at 60Hz, in microseconds
+    private const SCROLL_SETTLE_READS = 5;
+    private const SCROLL_UNMOVED_SETTLE_READS = 15; // covers compositor-to-main commit latency when nothing scrolls
+
     /**
      * @var Page
      */
@@ -141,6 +146,7 @@ class Mouse
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
      *
      * @return $this
      */
@@ -156,6 +162,7 @@ class Mouse
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
      *
      * @return $this
      */
@@ -167,10 +174,16 @@ class Mouse
     /**
      * Scroll a positive or negative distance using the mouseWheel event type.
      *
+     * The requested distance is clamped to the current scroll boundaries of the page. The method
+     * returns once the scroll position has settled, which is not necessarily at the requested
+     * distance: the page may shrink, grow, lock scrolling, or consume the wheel event while the
+     * scroll is in flight.
+     *
      * @param int $distanceY Distance in pixels for the Y axis
      * @param int $distanceX (optional) Distance in pixels for the X axis
      *
      * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\CommunicationException\ResponseHasError
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
      *
@@ -180,17 +193,24 @@ class Mouse
     {
         $this->page->assertNotClosed();
 
-        $scrollableArea = $this->page->getLayoutMetrics()->getCssContentSize();
-        $visibleArea = $this->page->getLayoutMetrics()->getCssVisualViewport();
+        $metrics = $this->page->getLayoutMetrics();
+        $scrollableArea = $metrics->getCssContentSize();
+        $visibleArea = $metrics->getCssVisualViewport();
 
-        $maximumX = $scrollableArea['width'] - $visibleArea['clientWidth'];
-        $maximumY = $scrollableArea['height'] - $visibleArea['clientHeight'];
+        // the protocol reports doubles that may be fractional (zoom, device pixel ratio)
+        $startX = (int) $visibleArea['pageX'];
+        $startY = (int) $visibleArea['pageY'];
 
-        $distanceX = $this->getMaximumDistance($distanceX, $visibleArea['pageX'], $maximumX);
-        $distanceY = $this->getMaximumDistance($distanceY, $visibleArea['pageY'], $maximumY);
+        // scrollbar asymmetries can push the raw difference slightly negative
+        $maximumX = \max(0, (int) ($scrollableArea['width'] - $visibleArea['clientWidth']));
+        $maximumY = \max(0, (int) ($scrollableArea['height'] - $visibleArea['clientHeight']));
 
-        $targetX = $visibleArea['pageX'] + $distanceX;
-        $targetY = $visibleArea['pageY'] + $distanceY;
+        $distanceX = $this->getMaximumDistance($distanceX, $startX, $maximumX);
+        $distanceY = $this->getMaximumDistance($distanceY, $startY, $maximumY);
+
+        if (0 === $distanceX && 0 === $distanceY) {
+            return $this;
+        }
 
         // make sure the mouse is on the screen
         $this->move($this->x, $this->y);
@@ -205,11 +225,12 @@ class Mouse
         ]));
 
         // wait until the scroll is done
-        Utils::tryWithTimeout(30000 * 1000, $this->waitForScroll($targetX, $targetY));
+        Utils::tryWithTimeout(self::SCROLL_TIMEOUT, $this->waitForScrollToSettle($startX, $startY, $startX + $distanceX, $startY + $distanceY));
 
         // set new position after move
-        $this->x += $distanceX;
-        $this->y += $distanceY;
+        $endPosition = $this->getCurrentScrollPosition();
+        $this->x += $endPosition['x'] - $startX;
+        $this->y += $endPosition['y'] - $startY;
 
         return $this;
     }
@@ -351,29 +372,72 @@ class Mouse
     }
 
     /**
-     * Wait for the browser to process the scroll command.
+     * Get the current page scroll position in CSS pixels.
      *
-     * Return the number of microseconds to wait before trying again or true in case of success.
+     * The protocol reports doubles that may be fractional (zoom, device pixel ratio), so the
+     * values are truncated to allow positions to be compared for equality.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\CommunicationException\ResponseHasError
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     *
+     * @return array{x: int, y: int}
+     */
+    private function getCurrentScrollPosition(): array
+    {
+        $viewport = $this->page->getLayoutMetrics()->getCssVisualViewport();
+
+        return ['x' => (int) $viewport['pageX'], 'y' => (int) $viewport['pageY']];
+    }
+
+    /**
+     * Wait for the page's scroll position to settle after a wheel event.
+     *
+     * The browser applies wheel scrolling on the compositor thread and commits the new offset to
+     * the main thread on a later frame, and the position can keep shifting afterwards (scroll
+     * anchoring, overlays, lazy-loaded content), so waiting for an exact pre-computed target can
+     * wait forever. Instead, return as soon as the expected target is reached, or once the
+     * position stops changing across consecutive reads. A position that never left the start is
+     * given a longer grace period, since the scroll may not have been committed yet or the wheel
+     * event may have been consumed by the page.
+     *
+     * Yields the number of microseconds to wait between reads.
      *
      * @see \HeadlessChromium\Utils::tryWithTimeout
      *
-     * @param int $targetX
-     * @param int $targetY
-     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\CommunicationException\ResponseHasError
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
-     *
-     * @return bool|\Generator
      */
-    private function waitForScroll(int $targetX, int $targetY)
+    private function waitForScrollToSettle(int $startX, int $startY, int $targetX, int $targetY): \Generator
     {
-        while (true) {
-            $visibleArea = $this->page->getLayoutMetrics()->getCssVisualViewport();
+        $stableReads = 0;
+        $lastX = $lastY = null;
 
-            if ($visibleArea['pageX'] === $targetX && $visibleArea['pageY'] === $targetY) {
-                return true;
+        while (true) {
+            $position = $this->getCurrentScrollPosition();
+
+            if ($position['x'] === $targetX && $position['y'] === $targetY) {
+                return;
             }
 
-            yield 1000;
+            if ($position['x'] === $lastX && $position['y'] === $lastY) {
+                ++$stableReads;
+            } else {
+                $stableReads = 1;
+                $lastX = $position['x'];
+                $lastY = $position['y'];
+            }
+
+            $moved = $position['x'] !== $startX || $position['y'] !== $startY;
+
+            if ($stableReads >= ($moved ? self::SCROLL_SETTLE_READS : self::SCROLL_UNMOVED_SETTLE_READS)) {
+                return;
+            }
+
+            yield self::SCROLL_POLL_INTERVAL;
         }
     }
 

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -102,6 +102,114 @@ class MouseApiTest extends BaseTestCase
     }
 
     /**
+     * Scrolling works when the scrollable area shrinks immediately after the scroll starts.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     */
+    public function testScrollDoesNotTimeOutWhenScrollableAreaShrinks(): void
+    {
+        $page = $this->openSitePage('scrollShrink.html');
+
+        $page->mouse()->scrollDown(4000); // Before patch this threw an OperationTimedOut Exception.
+
+        $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
+        $maximumY = $page
+            ->evaluate('document.documentElement.scrollHeight - window.innerHeight')
+            ->getReturnValue();
+
+        // We asked to scroll further than the shrunken page allows, so we end up
+        // exactly at the new (smaller) maximum. The actual regression guarantee
+        // is that scrollDown() returns at all instead of timing out.
+        self::assertSame($maximumY, $windowScrollY);
+    }
+
+    /**
+     * Scrolling works when an overlay pops up and locks scrolling immediately after the scroll starts.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     */
+    public function testScrollDoesNotTimeOutWhenModalLocksScrolling(): void
+    {
+        $page = $this->openSitePage('scrollLock.html');
+
+        $page->mouse()->scrollDown(4000); // Before patch this threw an OperationTimedOut Exception.
+
+        $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
+        $maximumY = $page
+            ->evaluate('document.documentElement.scrollHeight - window.innerHeight')
+            ->getReturnValue();
+
+        // Scrolling got locked, so the page can no longer be scrolled at all and
+        // we stay at the top. The guarantee the fix restores is that scrollDown()
+        // returns instead of timing out.
+        self::assertSame(0, $maximumY);
+        self::assertSame(0, $windowScrollY);
+    }
+
+    /**
+     * Scrolling works when the layout shifts (e.g. due to lazy loaded image) during scrolling.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     */
+    public function testScrollDoesNotTimeOutWhenLayoutShiftsDuringScroll(): void
+    {
+        $page = $this->openSitePage('infiniteScroll.html');
+
+        $page->mouse()->scrollDown(4000); // Before patch this threw an OperationTimedOut Exception.
+
+        $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
+        $maximumY = $page
+            ->evaluate('document.documentElement.scrollHeight - window.innerHeight')
+            ->getReturnValue();
+
+        // The page grew (it did not shrink), so we scrolled and ended up at a
+        // valid position within the new bounds rather than timing out. The exact
+        // position is timing-dependent.
+        self::assertGreaterThan(0, $windowScrollY);
+        self::assertLessThanOrEqual($maximumY, $windowScrollY);
+    }
+
+    /**
+     * Scrolling a page that cannot scroll is a no-op.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     */
+    public function testScrollOnNonScrollablePage(): void
+    {
+        $page = $this->openSitePage('b.html');
+
+        $page->mouse()->scrollDown(100);
+
+        self::assertSame(0, $page->evaluate('window.scrollY')->getReturnValue());
+        self::assertSame(['x' => 0, 'y' => 0], $page->mouse()->getPosition());
+    }
+
+    /**
+     * Scrolling returns when the page consumes the wheel event with preventDefault.
+     *
+     * @throws \HeadlessChromium\Exception\CommunicationException
+     * @throws \HeadlessChromium\Exception\NoResponseAvailable
+     * @throws \HeadlessChromium\Exception\OperationTimedOut
+     */
+    public function testScrollReturnsWhenWheelEventIsPrevented(): void
+    {
+        $page = $this->openSitePage('scrollPrevented.html');
+
+        $page->mouse()->scrollDown(500); // Before patch this threw an OperationTimedOut Exception.
+
+        self::assertSame(0, $page->evaluate('window.scrollY')->getReturnValue());
+        self::assertSame(['x' => 0, 'y' => 0], $page->mouse()->getPosition());
+    }
+
+    /**
      * @dataProvider providerFindElementWithSingleElement
      *
      * @throws \HeadlessChromium\Exception\CommunicationException

--- a/tests/resources/static-web/infiniteScroll.html
+++ b/tests/resources/static-web/infiniteScroll.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>infinite-scroll issue (lazy image above)</title>
+    <style>
+        html, body { margin: 0; padding: 0; font: 16px sans-serif; }
+        #header { height: 80px; background: #1565c0; color: #fff; padding: 8px; }
+        /* The lazy image has no reserved height until it loads (the common
+           cause of layout shift in real feeds). */
+        #lazyimg { display: block; width: 640px; max-width: 100%; margin: 12px; }
+        #feed { height: 12000px; background: linear-gradient(#cfe8ff, #084b97); }
+    </style>
+</head>
+<body>
+<div id="header">feed</div>
+<img id="lazyimg" alt="">
+<div id="feed">feed content</div>
+<script>
+    // On the scroll event we simulate the finished loading of a lazy-loaded image
+    // above the current position. Before patch, this caused an OperationTimedOut
+    // Exception, because it changed the expected scroll position.
+    var loaded = false;
+
+    window.addEventListener('scroll', function () {
+        if (loaded) {
+            return;
+        }
+        loaded = true;
+        // The image finishes loading: assigning the src makes it reflow to its
+        // intrinsic 640x420 size, pushing the feed below it down.
+        var svg = "<svg xmlns='http://www.w3.org/2000/svg' width='640' height='420'>"
+            + "<rect width='100%' height='100%' fill='rgb(120,144,156)'/>"
+            + "<text x='320' y='220' font-size='32' fill='white' text-anchor='middle'"
+            + " font-family='sans-serif'>lazy-loaded image</text></svg>";
+        document.getElementById('lazyimg').src = 'data:image/svg+xml,' + encodeURIComponent(svg);
+    }, { passive: true });
+</script>
+</body>
+</html>

--- a/tests/resources/static-web/scrollLock.html
+++ b/tests/resources/static-web/scrollLock.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>scroll-lock issue</title>
+    <style>
+        html, body { margin: 0; padding: 0; font: 16px sans-serif; }
+        #spacer { height: 5000px; background: linear-gradient(#cfe8ff, #084b97); }
+        #overlay {
+            display: none;
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, .25);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+        }
+        #dialog {
+            width: 75vw;
+            height: 75vh;
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            padding: 40px;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, .45);
+            text-align: center;
+        }
+        #dialog h1 { margin: 0; font-size: 28px; color: #b71c1c; }
+        #dialog p { margin: 0; font-size: 18px; color: #333; }
+    </style>
+</head>
+<body>
+<div id="spacer">scroll me</div>
+<div id="overlay">
+    <div id="dialog">
+        <h1>A modal popped up</h1>
+        <p>…and locked scrolling (the page is now position:fixed)</p>
+    </div>
+</div>
+<script>
+    // On the scroll event we immediately show the modal overlay and set
+    // a scroll lock on the body. Before patch, this caused an OperationTimedOut
+    // Exception, because it changes the expected scroll position.
+    var locked = false;
+    window.addEventListener('scroll', function () {
+        if (locked) {
+            return;
+        }
+        locked = true;
+        document.body.style.position = 'fixed';
+        document.body.style.top = '0';
+        document.body.style.left = '0';
+        document.body.style.right = '0';
+        document.documentElement.style.overflow = 'hidden';
+        document.getElementById('overlay').style.display = 'flex';
+    }, { passive: true });
+</script>
+</body>
+</html>

--- a/tests/resources/static-web/scrollPrevented.html
+++ b/tests/resources/static-web/scrollPrevented.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>wheel prevented</title>
+    <style>
+        html, body { margin: 0; padding: 0; }
+        #spacer { height: 5000px; }
+    </style>
+</head>
+<body>
+<div id="spacer">wheel events are consumed</div>
+<script>
+    // A non-passive wheel listener that consumes the event: the page never scrolls,
+    // and the devtools protocol exposes no signal that this happened.
+    window.addEventListener('wheel', function (event) {
+        event.preventDefault();
+    }, { passive: false });
+</script>
+</body>
+</html>

--- a/tests/resources/static-web/scrollShrink.html
+++ b/tests/resources/static-web/scrollShrink.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>scroll timeout issue</title>
+    <style>
+        html, body { margin: 0; padding: 0; }
+        #spacer { height: 5000px; background: linear-gradient(#cfe8ff, #1565c0); }
+    </style>
+</head>
+<body>
+<div id="spacer">scroll me</div>
+<script>
+    // On the scroll event we immediately shrink height of the page (scrollable area).
+    // Before patch, this caused an OperationTimedOut Exception, because it changes
+    // the expected scroll position.
+    var shrunk = false;
+    window.addEventListener('scroll', function () {
+        if (shrunk) {
+            return;
+        }
+        shrunk = true;
+        // New max scroll becomes (1500 - viewportHeight), far below the
+        // original target that was computed against a 5000px page.
+        document.getElementById('spacer').style.height = '1500px';
+        document.getElementById('spacer').innerText = 'scrollable area shrunk';
+    }, { passive: true });
+</script>
+</body>
+</html>


### PR DESCRIPTION
When Mouse::scroll() dispatches a mouseWheel event, it computes an exact target position up front and then polls the layout metrics until the visual viewport matches it, timing out after 30 seconds. That target is often unreachable: Chromium applies wheel scrolling on the compositor thread and can move the offset again afterwards (scroll anchoring when the layout shifts, clamping when the content shrinks), the page can lock scrolling, the wheel can latch onto a sub-scroller under the cursor, and a non-passive wheel listener can consume the event outright with no signal exposed over the protocol. The metrics are also reported as doubles that become fractional under zoom or a non-integer device pixel ratio, in which case the strict comparison against an integer target can never succeed at all.

This replaces the exact-target wait with observation of the actual scroll position. The wait returns as soon as the position reaches the expected target, which keeps the common case as fast as before, or once the position stops changing across consecutive reads, with a longer grace period when the position never left the start so that a consumed or locked scroll returns cleanly instead of timing out. The requested distance is still clamped to the page's scroll boundaries, a scroll that clamps to nothing now returns without dispatching an event, and the tracked mouse position is advanced by the distance the page actually scrolled rather than the distance requested. The hard timeout, now only reachable if the position never settles, drops from 30 to 10 seconds, and the wait between reads is one frame instead of one millisecond.

The reproduction fixtures and their regression tests for the shrinking, locking and layout-shift cases are the work of @otsch in #727, and this change follows the settling approach proposed there; it additionally covers the consumed-wheel case and halves the protocol round trips per read by reusing a single getLayoutMetrics response. Closes #678. Closes #727.