### PR TITLE
[1.16] Apply script execution setting to existing pages

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -121,8 +121,16 @@ class Browser
     {
         $this->pageScriptExecutionDisabled = $disabled;
 
+        // send the message to all pages before awaiting the responses, so that
+        // a page that fails to respond does not prevent updating the others
+        $responses = [];
+
         foreach ($this->pages as $page) {
-            $page->setScriptExecution(!$disabled)->await();
+            $responses[] = $page->setScriptExecution(!$disabled);
+        }
+
+        foreach ($responses as $response) {
+            $response->await();
         }
     }
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -111,11 +111,19 @@ class Browser
     }
 
     /**
-     * Disable or enable JavaScript execution for every new page created by this browser.
+     * Disable or enable JavaScript execution for existing pages and pages created later.
+     *
+     * @throws CommunicationException
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
      */
     public function setPageScriptExecutionDisabled(bool $disabled = true): void
     {
         $this->pageScriptExecutionDisabled = $disabled;
+
+        foreach ($this->pages as $page) {
+            $page->setScriptExecution(!$disabled)->await();
+        }
     }
 
     /**

--- a/tests/BrowserFactoryTest.php
+++ b/tests/BrowserFactoryTest.php
@@ -144,6 +144,37 @@ class BrowserFactoryTest extends BaseTestCase
         );
     }
 
+    public function testPageScriptExecutionDisabledSetterUpdatesExistingPages(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+
+        $page = $browser->createPage();
+        $page->navigate(self::sitePath('javascript.html'))->waitForNavigation();
+
+        self::assertSame(
+            'javascript enabled',
+            $page->evaluate('document.body.innerText')->getReturnValue()
+        );
+
+        $browser->setPageScriptExecutionDisabled();
+        $page->navigate(self::sitePath('javascript.html'))->waitForNavigation();
+
+        self::assertSame(
+            'javascript disabled',
+            $page->evaluate('document.body.innerText')->getReturnValue()
+        );
+
+        $browser->setPageScriptExecutionDisabled(false);
+        $page->navigate(self::sitePath('javascript.html'))->waitForNavigation();
+
+        self::assertSame(
+            'javascript enabled',
+            $page->evaluate('document.body.innerText')->getReturnValue()
+        );
+    }
+
     public function testConnectToBrowser(): void
     {
         // create a browser


### PR DESCRIPTION
This updates the browser-level JavaScript execution toggle so changing it also applies to pages that have already been created, keeping the public setter consistent with pages created later.