### PR TITLE
[1.16] Allow choosing the box model in `Node::getPosition()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 1.16.0 (UPCOMING)
 
 * Add `disableJavascript` option
+* Allow choosing the box model in `Node::getPosition()`
 
 
 ## 1.15.0 (2025-12-27)

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -133,6 +133,10 @@ class Node
      */
     public function getPosition(string $boxModel = 'content'): ?NodePosition
     {
+        if (!\in_array($boxModel, ['content', 'padding', 'border', 'margin'], true)) {
+            throw new \InvalidArgumentException('Invalid box model "'.$boxModel.'" for node position. Box model must be "content", "padding", "border" or "margin".');
+        }
+
         $message = new Message('DOM.getBoxModel', [
             'nodeId' => $this->getNodeIdForRequest(),
         ]);

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -128,7 +128,10 @@ class Node
         return $this->getAttributes()->get($name);
     }
 
-    public function getPosition(): ?NodePosition
+    /**
+     * @param 'content'|'padding'|'border'|'margin' $boxModel
+     */
+    public function getPosition(string $boxModel = 'content'): ?NodePosition
     {
         $message = new Message('DOM.getBoxModel', [
             'nodeId' => $this->getNodeIdForRequest(),
@@ -137,7 +140,7 @@ class Node
 
         $this->assertNotError($response);
 
-        $points = $response->getResultData('model')['content'];
+        $points = $response->getResultData('model')[$boxModel] ?? null;
 
         if (null !== $points) {
             return new NodePosition($points);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -5,6 +5,7 @@ namespace HeadlessChromium\Test;
 use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Exception\StaleElementException;
+use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @covers \HeadlessChromium\Dom\Dom
@@ -24,14 +25,6 @@ class DomTest extends BaseTestCase
     {
         parent::tearDownAfterClass();
         self::$browser->close();
-    }
-
-    private function openSitePage($file)
-    {
-        $page = self::$browser->createPage();
-        $page->navigate(self::sitePath($file))->waitForNavigation();
-
-        return $page;
     }
 
     public function testSearchByCssSelector(): void
@@ -140,6 +133,45 @@ class DomTest extends BaseTestCase
         self::assertSame('hello', $value);
     }
 
+    #[TestWith(['margin', 0, 0, 310, 360])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['border', 20, 10, 270, 340])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['padding', 25, 15, 260, 330])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['content', 55, 30, 200, 300])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith([null, 55, 30, 200, 300])]
+    /** @phpstan-ignore attribute.nonRepeatable */
+    #[TestWith(['-invalid-', 0, 0, 0, 0])]
+    public function testGetPosition(
+        ?string $boxModel,
+        float $expectedX,
+        float $expectedY,
+        float $expectedWidth,
+        float $expectedHeight,
+    ): void {
+        $page = $this->openSitePage('boxModel.html');
+
+        $element = $page->dom()->querySelector('#elem');
+
+        if (null !== $boxModel) {
+            $position = $element->getPosition($boxModel);
+        } else {
+            $position = $element->getPosition();
+        }
+
+        if ('-invalid-' !== $boxModel) {
+            self::assertNotNull($position);
+            self::assertSame($expectedX, $position->getX());
+            self::assertSame($expectedY, $position->getY());
+            self::assertSame($expectedWidth, $position->getWidth());
+            self::assertSame($expectedHeight, $position->getHeight());
+        } else {
+            self::assertNull($position);
+        }
+    }
+
     public function testUploadFile(): void
     {
         $page = $this->openSitePage('domForm.html');
@@ -239,5 +271,13 @@ class DomTest extends BaseTestCase
         $this->expectException(StaleElementException::class);
 
         $inputNode->sendKeys('test');
+    }
+
+    private function openSitePage($file)
+    {
+        $page = self::$browser->createPage();
+        $page->navigate(self::sitePath($file))->waitForNavigation();
+
+        return $page;
     }
 }

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -2,10 +2,10 @@
 
 namespace HeadlessChromium\Test;
 
+use Generator;
 use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Exception\StaleElementException;
-use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @covers \HeadlessChromium\Dom\Dom
@@ -25,6 +25,14 @@ class DomTest extends BaseTestCase
     {
         parent::tearDownAfterClass();
         self::$browser->close();
+    }
+
+    private function openSitePage($file)
+    {
+        $page = self::$browser->createPage();
+        $page->navigate(self::sitePath($file))->waitForNavigation();
+
+        return $page;
     }
 
     public function testSearchByCssSelector(): void
@@ -133,24 +141,11 @@ class DomTest extends BaseTestCase
         self::assertSame('hello', $value);
     }
 
-    #[TestWith(['margin', 0, 0, 310, 360])]
-    /** @phpstan-ignore attribute.nonRepeatable */
-    #[TestWith(['border', 20, 10, 270, 340])]
-    /** @phpstan-ignore attribute.nonRepeatable */
-    #[TestWith(['padding', 25, 15, 260, 330])]
-    /** @phpstan-ignore attribute.nonRepeatable */
-    #[TestWith(['content', 55, 30, 200, 300])]
-    /** @phpstan-ignore attribute.nonRepeatable */
-    #[TestWith([null, 55, 30, 200, 300])]
-    /** @phpstan-ignore attribute.nonRepeatable */
-    #[TestWith(['-invalid-', 0, 0, 0, 0])]
-    public function testGetPosition(
-        ?string $boxModel,
-        float $expectedX,
-        float $expectedY,
-        float $expectedWidth,
-        float $expectedHeight,
-    ): void {
+    /**
+     * @dataProvider providerGetPosition
+     */
+    public function testGetPosition(?string $boxModel, float $expectedX, float $expectedY, float $expectedWidth, float $expectedHeight): void
+    {
         $page = $this->openSitePage('boxModel.html');
 
         $element = $page->dom()->querySelector('#elem');
@@ -161,15 +156,34 @@ class DomTest extends BaseTestCase
             $position = $element->getPosition();
         }
 
-        if ('-invalid-' !== $boxModel) {
-            self::assertNotNull($position);
-            self::assertSame($expectedX, $position->getX());
-            self::assertSame($expectedY, $position->getY());
-            self::assertSame($expectedWidth, $position->getWidth());
-            self::assertSame($expectedHeight, $position->getHeight());
-        } else {
-            self::assertNull($position);
-        }
+        self::assertNotNull($position);
+        self::assertSame($expectedX, $position->getX());
+        self::assertSame($expectedY, $position->getY());
+        self::assertSame($expectedWidth, $position->getWidth());
+        self::assertSame($expectedHeight, $position->getHeight());
+    }
+
+    /**
+     * @return Generator<string, array{?string, float, float, float, float}>
+     */
+    public static function providerGetPosition(): Generator
+    {
+        yield 'margin' => ['margin', 0.0, 0.0, 310.0, 360.0];
+        yield 'border' => ['border', 20.0, 10.0, 270.0, 340.0];
+        yield 'padding' => ['padding', 25.0, 15.0, 260.0, 330.0];
+        yield 'content' => ['content', 55.0, 30.0, 200.0, 300.0];
+        yield 'default' => [null, 55.0, 30.0, 200.0, 300.0];
+    }
+
+    public function testGetPositionWithInvalidBoxModel(): void
+    {
+        $page = $this->openSitePage('boxModel.html');
+
+        $element = $page->dom()->querySelector('#elem');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $element->getPosition('-invalid-');
     }
 
     public function testUploadFile(): void
@@ -271,13 +285,5 @@ class DomTest extends BaseTestCase
         $this->expectException(StaleElementException::class);
 
         $inputNode->sendKeys('test');
-    }
-
-    private function openSitePage($file)
-    {
-        $page = self::$browser->createPage();
-        $page->navigate(self::sitePath($file))->waitForNavigation();
-
-        return $page;
     }
 }

--- a/tests/resources/static-web/boxModel.html
+++ b/tests/resources/static-web/boxModel.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <title>box model - test</title>
+
+    <style>
+        html, body{
+            width: 500px;
+            height: 500px;
+            margin: 0;
+            padding: 0;
+        }
+
+        div {
+            width: 200px;
+            height: 300px;
+            margin: 10px 20px;
+            padding: 15px 30px;
+            border: 5px solid red;
+        }
+    </style>
+</head>
+<body>
+<div id="elem">
+    some content
+</div>
+</body>
+</html>


### PR DESCRIPTION
Node::getPosition() reads only the content box from DOM.getBoxModel, so there is no way to measure an element including its padding, border or margin, which is useful when rendering single page documents among other things. This picks up @aprat84's change from #726, retargeted at 1.16 since it adds new behaviour: getPosition() accepts an optional box model argument defaulting to content, so existing calls are unaffected, and the original commit is included as authored.

A follow-up commit applies some corrections. An invalid box model now throws an InvalidArgumentException, following the precedent of the screenshot format validation, rather than silently returning null, since a null return otherwise means the element could not be measured and a typo should not masquerade as that. The test is rewritten to use a data provider instead of PHP 8 attributes, because #[TestWith] requires PHPUnit 10 and the trailing comma in the parameter list is a parse error on PHP 7.4, so the original test file would have broken the PHP 7.4 and 8.0 builds, which also makes the phpstan-ignore workarounds unnecessary. The PHPStan platform constraint is left untouched as PHPStan must run on PHP 7.4 only, and a changelog entry is included.

Closes #726.