### PR TITLE
[1.16] Wait for socket data instead of polling for responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4.15 || ^8.0.2",
-        "chrome-php/wrench": "^1.8",
+        "chrome-php/wrench": "^1.9@dev",
         "evenement/evenement": "^3.0.1",
         "monolog/monolog": "^1.27.1 || ^2.8 || ^3.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -348,6 +348,18 @@ class Connection extends EventEmitter implements LoggerAwareInterface
         return false;
     }
 
+    /**
+     * Waits for data to be available on the socket, when supported.
+     *
+     * @param float $maxSeconds the maximum amount of time to wait, in seconds
+     *
+     * @return bool true if data is available to be read
+     */
+    public function waitForData(float $maxSeconds): bool
+    {
+        return $this->wsClient instanceof WaitForDataInterface && $this->wsClient->waitForData($maxSeconds);
+    }
+
     public function processAllEvents(): void
     {
         if (false === $this->wsClient instanceof WaitForDataInterface) {

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -126,9 +126,6 @@ class ResponseReader
     private function waitForResponseGenerator()
     {
         while (true) {
-            // 50 microseconds between each iteration
-            $tryDelay = 50;
-
             // read available response
             $hasResponse = $this->checkForResponse();
 
@@ -136,6 +133,10 @@ class ResponseReader
             if ($hasResponse) {
                 return $this->getResponse();
             }
+
+            // wait for data to arrive on the socket instead of polling,
+            // falling back to 50 microseconds between each iteration
+            $tryDelay = $this->connection->waitForData(0.05) ? 0 : 50;
 
             // wait before next check
             yield $tryDelay;

--- a/src/Communication/Socket/Wrench.php
+++ b/src/Communication/Socket/Wrench.php
@@ -140,6 +140,6 @@ class Wrench implements SocketInterface, LoggerAwareInterface, WaitForDataInterf
 
     public function waitForData(float $maxSeconds): bool
     {
-        return $this->client->waitForData($maxSeconds);
+        return true === $this->client->waitForData($maxSeconds);
     }
 }

--- a/tests/Communication/ConnectionTest.php
+++ b/tests/Communication/ConnectionTest.php
@@ -54,6 +54,13 @@ class ConnectionTest extends TestCase
         self::assertFalse($this->mocSocket->isConnected());
     }
 
+    public function testWaitForDataUnsupportedBySocket(): void
+    {
+        $connection = new Connection($this->mocSocket);
+
+        self::assertFalse($connection->waitForData(0));
+    }
+
     public function testCreateSession(): void
     {
         $connection = new Connection($this->mocSocket);


### PR DESCRIPTION
With wrench 1.9, receive() drains data that has already arrived and never blocks waiting for data, which turns ResponseReader's 50 microsecond retry loop into a hot poll that issues tens of thousands of syscalls per second for the whole duration of any slow protocol operation. This change parks the wait on the socket instead: Connection gains a waitForData() method that delegates to the underlying socket when it implements WaitForDataInterface, and ResponseReader waits on it in 50 millisecond slices, so the loop wakes the moment data lands and only falls back to the previous 50 microsecond delay when the socket cannot wait, as the mock socket in the unit tests cannot. The wrench socket wrapper now also converts a null returned by the underlying client, which is typed to return a nullable boolean on select errors, into false rather than fatally violating its own return type on a dead socket. The wrench requirement moves to ^1.9@dev until 1.9.0 is tagged, at which point it should be tightened to ^1.9.