### PR TITLE
[1.16] Add `Page::authenticate` to answer HTTP authentication challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `disableJavascript` option
 * Allow choosing the box model in `Node::getPosition()`
 * Allow setting `referrer`, `referrerPolicy` and `transitionType` in `Page::navigate()`
+* Add `Page::authenticate` and `Page::clearAuthentication` methods
 
 
 ## 1.15.1 (UPCOMING)

--- a/README.md
+++ b/README.md
@@ -690,6 +690,21 @@ if ($cookieBar) {
 }
 ```
 
+### HTTP Authentication
+
+You can set credentials for HTTP Basic Authentication using `Page::authenticate` before navigating to a protected page or when using a proxy. If the credentials are invalid, an `AuthenticationFailed` exception is thrown.
+
+```php
+use HeadlessChromium\Exception\AuthenticationFailed;
+
+try {
+    $page->authenticate('username', 'password');
+    $page->navigate('http://example.com/protected')->waitForNavigation();
+} catch (AuthenticationFailed $e) {
+    // invalid credentials
+}
+```
+
 ### Set user agent
 
 You can set up a user-agent per page:

--- a/README.md
+++ b/README.md
@@ -692,18 +692,22 @@ if ($cookieBar) {
 
 ### HTTP Authentication
 
-You can set credentials for HTTP Basic Authentication using `Page::authenticate` before navigating to a protected page or when using a proxy. If the credentials are invalid, an `AuthenticationFailed` exception is thrown.
+You can set credentials to answer HTTP authentication challenges, such as basic authentication or a proxy requiring authentication, using `Page::authenticate` before navigating. If the credentials are rejected, an `AuthenticationFailed` exception is thrown while waiting for the navigation.
 
 ```php
 use HeadlessChromium\Exception\AuthenticationFailed;
 
 try {
-    $page->authenticate('username', 'password');
-    $page->navigate('http://example.com/protected')->waitForNavigation();
+    $page->authenticate('username', 'password', 'https://example.com');
+    $page->navigate('https://example.com/protected')->waitForNavigation();
 } catch (AuthenticationFailed $e) {
     // invalid credentials
 }
 ```
+
+The origin argument restricts the credentials to challenges coming from that origin, compared by scheme, host and port, so that they cannot leak to other origins, e.g. through pages embedding cross-origin resources. Omit the origin to answer every challenge, e.g. when authenticating to a proxy. Use `Page::clearAuthentication` to remove the credentials again.
+
+`Page::authenticate` intercepts requests using the DevTools fetch domain, so it should not be combined with custom `Fetch.enable` usage on the same page.
 
 ### Set user agent
 

--- a/src/Exception/AuthenticationFailed.php
+++ b/src/Exception/AuthenticationFailed.php
@@ -11,6 +11,8 @@
 
 namespace HeadlessChromium\Exception;
 
-class AuthenticationFailed extends \Exception
+use Exception;
+
+class AuthenticationFailed extends Exception
 {
 }

--- a/src/Exception/AuthenticationFailed.php
+++ b/src/Exception/AuthenticationFailed.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Exception;
+
+class AuthenticationFailed extends \Exception
+{
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -31,6 +31,7 @@ use HeadlessChromium\Exception\OperationTimedOut;
 use HeadlessChromium\Exception\TargetDestroyed;
 use HeadlessChromium\Input\Keyboard;
 use HeadlessChromium\Input\Mouse;
+use HeadlessChromium\PageUtils\AuthenticationScope;
 use HeadlessChromium\PageUtils\CookiesGetter;
 use HeadlessChromium\PageUtils\PageEvaluation;
 use HeadlessChromium\PageUtils\PageLayoutMetrics;
@@ -78,6 +79,34 @@ class Page
      * @var Dom|null
      */
     protected $dom;
+
+    /**
+     * Credentials to be used to answer HTTP authentication challenges.
+     *
+     * @var array{username: string, password: string}|null
+     */
+    protected $authCredentials;
+
+    /**
+     * Scope the authentication credentials are restricted to.
+     *
+     * @var AuthenticationScope|null
+     */
+    protected $authScope;
+
+    /**
+     * Challenges that were already provided the credentials.
+     *
+     * @var array<string, true>
+     */
+    protected $attemptedAuthentications = [];
+
+    /**
+     * Whether the authentication challenge listeners were registered.
+     *
+     * @var bool
+     */
+    protected $authListenersRegistered = false;
 
     /**
      * Page constructor.
@@ -162,58 +191,137 @@ class Page
     }
 
     /**
-     * Sets credentials to be used when the page encounters an HTTP authentication challenge.
+     * Sets credentials to be used when the page encounters an HTTP authentication challenge,
+     * such as basic authentication or a proxy requiring authentication.
      *
-     * @throws AuthenticationFailed
+     * When an origin is given, the credentials are only used to answer challenges coming from
+     * that origin, compared by scheme, host and port, and only requests within that origin are
+     * intercepted. Omit the origin to answer every challenge, e.g. when authenticating to a proxy.
+     *
+     * Calling this method again replaces the credentials and the origin. If the browser rejects
+     * the credentials by repeating a challenge, the request is cancelled and an
+     * AuthenticationFailed exception is thrown from the method that is reading the browser
+     * messages at that time, usually PageNavigation::waitForNavigation.
+     *
+     * @throws InvalidArgumentException
      * @throws CommunicationException
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
      */
-    public function authenticate(string $username, string $password): void
+    public function authenticate(string $username, string $password, ?string $origin = null): void
     {
         $this->assertNotClosed();
 
-        $credentialsAttempted = false;
+        $scope = null !== $origin ? new AuthenticationScope($origin) : null;
 
-        $this->getSession()->on('method:Fetch.authRequired', function (array $params) use ($username, $password, &$credentialsAttempted) {
-            if ($credentialsAttempted) {
-                $this->getSession()->sendMessageSync(
-                    new Message('Fetch.continueWithAuth', [
-                        'requestId' => $params['requestId'],
-                        'authChallengeResponse' => [
-                            'response' => 'CancelAuth',
-                        ],
-                    ])
-                );
+        $this->authCredentials = ['username' => $username, 'password' => $password];
+        $this->authScope = $scope;
+        $this->attemptedAuthentications = [];
+
+        $this->registerAuthenticationListeners();
+
+        $this->getSession()->sendMessageSync(
+            new Message('Fetch.enable', [
+                'handleAuthRequests' => true,
+                'patterns' => [
+                    ['urlPattern' => null !== $scope ? $scope->getUrlPattern() : '*'],
+                ],
+            ])
+        );
+    }
+
+    /**
+     * Removes the credentials set with Page::authenticate and stops intercepting requests.
+     *
+     * @throws CommunicationException
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
+     */
+    public function clearAuthentication(): void
+    {
+        $this->assertNotClosed();
+
+        if (null === $this->authCredentials) {
+            return;
+        }
+
+        $this->authCredentials = null;
+        $this->authScope = null;
+        $this->attemptedAuthentications = [];
+
+        $this->getSession()->sendMessageSync(new Message('Fetch.disable'));
+    }
+
+    /**
+     * Registers the fetch domain listeners used to answer authentication challenges.
+     */
+    private function registerAuthenticationListeners(): void
+    {
+        if ($this->authListenersRegistered) {
+            return;
+        }
+
+        $this->authListenersRegistered = true;
+
+        $this->getSession()->on('method:Fetch.authRequired', function (array $params): void {
+            $requestId = $params['requestId'];
+            $challenge = $params['authChallenge'] ?? [];
+
+            $attemptKey = \implode("\0", [
+                $requestId,
+                $challenge['source'] ?? '',
+                $challenge['origin'] ?? '',
+                $challenge['scheme'] ?? '',
+                $challenge['realm'] ?? '',
+            ]);
+
+            // a challenge that was already provided the credentials means they were rejected
+            if (\array_key_exists($attemptKey, $this->attemptedAuthentications)) {
+                $this->cancelAuthenticationChallenge($requestId);
 
                 throw new AuthenticationFailed('Authentication failed: invalid credentials.');
             }
 
-            $credentialsAttempted = true;
+            // cancel out of scope challenges without exposing the credentials
+            if (null === $this->authCredentials || (null !== $this->authScope && !$this->authScope->matchesOrigin($challenge['origin'] ?? ''))) {
+                $this->cancelAuthenticationChallenge($requestId);
+
+                return;
+            }
+
+            $this->attemptedAuthentications[$attemptKey] = true;
 
             $this->getSession()->sendMessageSync(
                 new Message('Fetch.continueWithAuth', [
-                    'requestId' => $params['requestId'],
+                    'requestId' => $requestId,
                     'authChallengeResponse' => [
                         'response' => 'ProvideCredentials',
-                        'username' => $username,
-                        'password' => $password,
+                        'username' => $this->authCredentials['username'],
+                        'password' => $this->authCredentials['password'],
                     ],
                 ])
             );
         });
 
-        $this->getSession()->on('method:Fetch.requestPaused', function (array $params) {
+        $this->getSession()->on('method:Fetch.requestPaused', function (array $params): void {
             $this->getSession()->sendMessageSync(
                 new Message('Fetch.continueRequest', [
                     'requestId' => $params['requestId'],
                 ])
             );
         });
+    }
 
+    /**
+     * Cancels an authentication challenge without exposing the credentials.
+     */
+    private function cancelAuthenticationChallenge(string $requestId): void
+    {
         $this->getSession()->sendMessageSync(
-            new Message('Fetch.enable', [
-                'handleAuthRequests' => true,
-                'patterns' => [
-                    ['urlPattern' => '*'],
+            new Message('Fetch.continueWithAuth', [
+                'requestId' => $requestId,
+                'authChallengeResponse' => [
+                    'response' => 'CancelAuth',
                 ],
             ])
         );

--- a/src/Page.php
+++ b/src/Page.php
@@ -21,6 +21,7 @@ use HeadlessChromium\Dom\Dom;
 use HeadlessChromium\Dom\Node;
 use HeadlessChromium\Dom\Selector\CssSelector;
 use HeadlessChromium\Dom\Selector\Selector;
+use HeadlessChromium\Exception\AuthenticationFailed;
 use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\EvaluationFailed;
 use HeadlessChromium\Exception\InvalidTimezoneId;
@@ -158,6 +159,64 @@ class Page
         $this->assertNotClosed();
 
         return $this->target->getSession();
+    }
+
+    /**
+     * Sets credentials to be used when the page encounters an HTTP authentication challenge.
+     *
+     * @throws AuthenticationFailed
+     * @throws CommunicationException
+     */
+    public function authenticate(string $username, string $password): void
+    {
+        $this->assertNotClosed();
+
+        $credentialsAttempted = false;
+
+        $this->getSession()->on('method:Fetch.authRequired', function (array $params) use ($username, $password, &$credentialsAttempted) {
+            if ($credentialsAttempted) {
+                $this->getSession()->sendMessageSync(
+                    new Message('Fetch.continueWithAuth', [
+                        'requestId' => $params['requestId'],
+                        'authChallengeResponse' => [
+                            'response' => 'CancelAuth',
+                        ],
+                    ])
+                );
+
+                throw new AuthenticationFailed('Authentication failed: invalid credentials.');
+            }
+
+            $credentialsAttempted = true;
+
+            $this->getSession()->sendMessageSync(
+                new Message('Fetch.continueWithAuth', [
+                    'requestId' => $params['requestId'],
+                    'authChallengeResponse' => [
+                        'response' => 'ProvideCredentials',
+                        'username' => $username,
+                        'password' => $password,
+                    ],
+                ])
+            );
+        });
+
+        $this->getSession()->on('method:Fetch.requestPaused', function (array $params) {
+            $this->getSession()->sendMessageSync(
+                new Message('Fetch.continueRequest', [
+                    'requestId' => $params['requestId'],
+                ])
+            );
+        });
+
+        $this->getSession()->sendMessageSync(
+            new Message('Fetch.enable', [
+                'handleAuthRequests' => true,
+                'patterns' => [
+                    ['urlPattern' => '*'],
+                ],
+            ])
+        );
     }
 
     /**

--- a/src/PageUtils/AuthenticationScope.php
+++ b/src/PageUtils/AuthenticationScope.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\PageUtils;
+
+use InvalidArgumentException;
+
+/**
+ * Restricts authentication credentials to a single web origin.
+ */
+class AuthenticationScope
+{
+    /**
+     * @var string
+     */
+    protected $scheme;
+
+    /**
+     * @var string
+     */
+    protected $host;
+
+    /**
+     * @var int
+     */
+    protected $port;
+
+    /**
+     * @param string $origin an absolute http or https URI; any path, query or fragment is ignored
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string $origin)
+    {
+        $parts = \parse_url($origin);
+
+        if (false === $parts || !isset($parts['scheme'], $parts['host'])) {
+            throw new InvalidArgumentException('The authentication origin must be an absolute http or https URI.');
+        }
+
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            throw new InvalidArgumentException('The authentication origin must not contain user info.');
+        }
+
+        $scheme = \strtolower($parts['scheme']);
+
+        if (!\in_array($scheme, ['http', 'https'], true)) {
+            throw new InvalidArgumentException('The authentication origin must use the http or https scheme.');
+        }
+
+        $host = \strtolower($parts['host']);
+
+        // colons are only valid within bracketed IPv6 literals
+        if ('[' === \substr($host, 0, 1)) {
+            $validHost = 1 === \preg_match('/^\[[0-9a-f:.]+\]$/D', $host);
+        } else {
+            $validHost = 1 === \preg_match('/^[a-z0-9\-._~%]+$/D', $host);
+        }
+
+        if (!$validHost) {
+            throw new InvalidArgumentException('The authentication origin host contains invalid characters.');
+        }
+
+        $this->scheme = $scheme;
+        $this->host = $host;
+        $this->port = $parts['port'] ?? ('https' === $scheme ? 443 : 80);
+    }
+
+    /**
+     * Check whether the given origin, e.g. of an authentication challenge, is the same web origin.
+     */
+    public function matchesOrigin(string $origin): bool
+    {
+        try {
+            $other = new self($origin);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+
+        return $other->scheme === $this->scheme && $other->host === $this->host && $other->port === $this->port;
+    }
+
+    /**
+     * Get the fetch request pattern matching only URLs within this origin.
+     */
+    public function getUrlPattern(): string
+    {
+        $pattern = $this->scheme.'://'.$this->host;
+
+        // browsers omit default ports in request URLs
+        if (('http' === $this->scheme && 80 !== $this->port) || ('https' === $this->scheme && 443 !== $this->port)) {
+            $pattern .= ':'.$this->port;
+        }
+
+        return $pattern.'/*';
+    }
+}

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Exception\AuthenticationFailed;
+
+/**
+ * @covers \HeadlessChromium\Page::authenticate
+ */
+class AuthenticationTest extends HttpEnabledTestCase
+{
+    private const AUTH_URL = 'basic-auth.php';
+    private const VALID_USER = 'testuser';
+    private const VALID_PASS = 'testpass';
+
+    public function testAuthenticateAllowsAccessWithValidCredentials(): void
+    {
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS);
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        // let's hit it twice to ensure subsequent requests also work
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+    }
+
+    public function testAuthenticateThrowsOnInvalidCredentials(): void
+    {
+        $this->expectException(AuthenticationFailed::class);
+
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->authenticate('wrong', 'credentials');
+
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+    }
+
+    public function testAuthenticateWithoutCredentialsDeniesAccess(): void
+    {
+        $page = (new BrowserFactory())->createBrowser()->createPage();
+
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringNotContainsString('Authenticated', $page->getHtml());
+    }
+}

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -11,11 +11,13 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Browser;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Exception\AuthenticationFailed;
+use InvalidArgumentException;
 
 /**
- * @covers \HeadlessChromium\Page::authenticate
+ * @covers \HeadlessChromium\Page
  */
 class AuthenticationTest extends HttpEnabledTestCase
 {
@@ -23,9 +25,24 @@ class AuthenticationTest extends HttpEnabledTestCase
     private const VALID_USER = 'testuser';
     private const VALID_PASS = 'testpass';
 
+    public static Browser\ProcessAwareBrowser $browser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $factory = new BrowserFactory();
+        self::$browser = $factory->createBrowser();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        self::$browser->close();
+    }
+
     public function testAuthenticateAllowsAccessWithValidCredentials(): void
     {
-        $page = (new BrowserFactory())->createBrowser()->createPage();
+        $page = self::$browser->createPage();
 
         $page->authenticate(self::VALID_USER, self::VALID_PASS);
         $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
@@ -36,20 +53,81 @@ class AuthenticationTest extends HttpEnabledTestCase
         self::assertStringContainsString('Authenticated', $page->getHtml());
     }
 
+    public function testAuthenticateUpdatesCredentialsForNewChallenges(): void
+    {
+        $page = self::$browser->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS);
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+
+        $page->authenticate('otheruser', 'otherpass');
+        $page->navigate(self::sitePath(self::AUTH_URL.'?user=otheruser&pass=otherpass'))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+    }
+
+    public function testAuthenticateScopedToOriginAllowsMatchingOrigin(): void
+    {
+        $page = self::$browser->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS, 'HTTP://LOCALHOST:8083/ignored/path');
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+    }
+
+    public function testAuthenticateScopedToDifferentOriginDoesNotSendCredentials(): void
+    {
+        $page = self::$browser->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS, 'http://127.0.0.1:8083');
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringNotContainsString('Authenticated', $page->getHtml());
+    }
+
+    public function testAuthenticateThrowsOnInvalidOrigin(): void
+    {
+        $page = self::$browser->createPage();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS, 'not an origin');
+    }
+
+    public function testClearAuthenticationStopsAnsweringChallenges(): void
+    {
+        $page = self::$browser->createPage();
+
+        $page->authenticate(self::VALID_USER, self::VALID_PASS);
+        $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
+
+        self::assertStringContainsString('Authenticated', $page->getHtml());
+
+        $page->clearAuthentication();
+
+        // expect different credentials so the previously cached ones no longer authenticate
+        $page->navigate(self::sitePath(self::AUTH_URL.'?user=otheruser&pass=otherpass'))->waitForNavigation();
+
+        self::assertStringNotContainsString('Authenticated', $page->getHtml());
+    }
+
     public function testAuthenticateThrowsOnInvalidCredentials(): void
     {
-        $this->expectException(AuthenticationFailed::class);
-
-        $page = (new BrowserFactory())->createBrowser()->createPage();
+        $page = self::$browser->createPage();
 
         $page->authenticate('wrong', 'credentials');
+
+        $this->expectException(AuthenticationFailed::class);
 
         $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
     }
 
     public function testAuthenticateWithoutCredentialsDeniesAccess(): void
     {
-        $page = (new BrowserFactory())->createBrowser()->createPage();
+        $page = self::$browser->createPage();
 
         $page->navigate(self::sitePath(self::AUTH_URL))->waitForNavigation();
 

--- a/tests/PageUtils/AuthenticationScopeTest.php
+++ b/tests/PageUtils/AuthenticationScopeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test\PageUtils;
+
+use HeadlessChromium\PageUtils\AuthenticationScope;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \HeadlessChromium\PageUtils\AuthenticationScope
+ */
+class AuthenticationScopeTest extends TestCase
+{
+    public function testNormalizesFullUrlToOrigin(): void
+    {
+        $scope = new AuthenticationScope('HTTP://Example.COM/protected?x=1#fragment');
+
+        self::assertTrue($scope->matchesOrigin('http://example.com'));
+        self::assertSame('http://example.com/*', $scope->getUrlPattern());
+    }
+
+    public function testDefaultPortsAreEquivalent(): void
+    {
+        self::assertTrue((new AuthenticationScope('http://example.com:80'))->matchesOrigin('http://example.com'));
+        self::assertTrue((new AuthenticationScope('https://example.com'))->matchesOrigin('https://example.com:443'));
+        self::assertSame('http://example.com/*', (new AuthenticationScope('http://example.com:80'))->getUrlPattern());
+    }
+
+    public function testKeepsNonDefaultPort(): void
+    {
+        $scope = new AuthenticationScope('http://example.com:8080/path');
+
+        self::assertTrue($scope->matchesOrigin('http://example.com:8080'));
+        self::assertSame('http://example.com:8080/*', $scope->getUrlPattern());
+    }
+
+    public function testIpv6Origin(): void
+    {
+        $scope = new AuthenticationScope('http://[::1]:8083/protected');
+
+        self::assertTrue($scope->matchesOrigin('http://[::1]:8083'));
+        self::assertFalse($scope->matchesOrigin('http://[::2]:8083'));
+    }
+
+    /**
+     * @dataProvider mismatchingOriginProvider
+     */
+    public function testDoesNotMatchDifferentOrigin(string $origin): void
+    {
+        $scope = new AuthenticationScope('http://example.com:8080');
+
+        self::assertFalse($scope->matchesOrigin($origin));
+    }
+
+    public static function mismatchingOriginProvider(): array
+    {
+        return [
+            'different port' => ['http://example.com:8081'],
+            'different scheme' => ['https://example.com:8080'],
+            'different host' => ['http://other.example.com:8080'],
+            'default port' => ['http://example.com'],
+            'opaque origin' => ['null'],
+            'empty origin' => [''],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidOriginProvider
+     */
+    public function testRejectsInvalidOrigin(string $origin): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new AuthenticationScope($origin);
+    }
+
+    public static function invalidOriginProvider(): array
+    {
+        return [
+            'missing scheme' => ['example.com'],
+            'scheme relative' => ['//example.com'],
+            'missing host' => ['http:'],
+            'empty host' => ['http://'],
+            'double port' => ['http://example.com:80:90'],
+            'unsupported scheme' => ['ftp://example.com'],
+            'user info' => ['http://user:pass@example.com'],
+            'wildcard host' => ['http://*.example.com'],
+            'space in host' => ['http://exam ple.com'],
+        ];
+    }
+}

--- a/tests/resources/static-web/basic-auth.php
+++ b/tests/resources/static-web/basic-auth.php
@@ -1,7 +1,16 @@
 <?php
 
-$expectedUser = 'testuser';
-$expectedPass = 'testpass';
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$expectedUser = $_GET['user'] ?? 'testuser';
+$expectedPass = $_GET['pass'] ?? 'testpass';
 
 $user = $_SERVER['PHP_AUTH_USER'] ?? null;
 $pass = $_SERVER['PHP_AUTH_PW'] ?? null;

--- a/tests/resources/static-web/basic-auth.php
+++ b/tests/resources/static-web/basic-auth.php
@@ -1,0 +1,16 @@
+<?php
+
+$expectedUser = 'testuser';
+$expectedPass = 'testpass';
+
+$user = $_SERVER['PHP_AUTH_USER'] ?? null;
+$pass = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+if ($user !== $expectedUser || $pass !== $expectedPass) {
+    \header('WWW-Authenticate: Basic realm="Test"');
+    \http_response_code(401);
+    echo 'Unauthorized';
+    exit;
+}
+
+echo 'Authenticated';


### PR DESCRIPTION
This replaces #728, retargeting the change at `1.16` since it is a new feature, keeping the original commit and adding follow-up commits with corrections. `Page::authenticate` sets credentials that are used to answer HTTP authentication challenges via `Fetch.continueWithAuth`, which, unlike `Page::setBasicAuthHeader`, also works with proxies that require a real challenge-response flow. The follow-up work tracks attempted authentications per challenge instead of using a single flag, because a page can legitimately receive more than one challenge, for example a server challenge after a proxy challenge or a second protected realm, and the original implementation would have cancelled any second challenge and reported an authentication failure even when the credentials were never rejected. It also makes repeated calls to `authenticate` replace the credentials instead of stacking duplicate listeners that would keep answering with the old credentials. The credentials can additionally be restricted to a single origin, compared by scheme, host and port, so that they cannot leak to other origins through cross-origin subresources or redirects; requests outside that origin are then not intercepted at all, and the origin can be omitted for proxy authentication. A new `Page::clearAuthentication` method removes the credentials again. Finally, it adds the missing CHANGELOG entry and aligns the documentation, the docblocks, and the new tests and fixture with the existing conventions. Resolves #634, #437, #158 and #29.