### PR TITLE
[1.16] Allow setting a referrer and other options in `Page::navigate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Add `disableJavascript` option
 * Allow choosing the box model in `Node::getPosition()`
+* Allow setting `referrer`, `referrerPolicy` and `transitionType` in `Page::navigate()`
 
 
 ## 1.15.1 (UPCOMING)

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ try {
 }
 ```
 
+The navigation accepts the options ``strict``, ``referrer``, ``referrerPolicy`` and ``transitionType``:
+
+```php
+// navigate with a custom referrer
+$navigation = $page->navigate('http://example.com', ['referrer' => 'https://google.com/']);
+```
+
 #### Evaluate script on the page
 
 Once the page has completed the navigation you can evaluate arbitrary script on this page:

--- a/src/Page.php
+++ b/src/Page.php
@@ -213,7 +213,10 @@ class Page
     /**
      * @param string $url
      * @param array  $options
-     * @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate for available options
+     *                        - strict: make waitForNavigation to fail if a new navigation is initiated. Default: false
+     *                        - referrer: the referrer URL to use for the navigation
+     *                        - referrerPolicy: the referrer policy to use for the navigation
+     *                        - transitionType: the transition type to use for the navigation
      *
      * @throws CommunicationException
      *

--- a/src/Page.php
+++ b/src/Page.php
@@ -213,7 +213,7 @@ class Page
     /**
      * @param string $url
      * @param array  $options
-     *                        - strict: make waitForNAvigation to fail if a new navigation is initiated. Default: false
+     * @see https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate for available options
      *
      * @throws CommunicationException
      *
@@ -223,7 +223,7 @@ class Page
     {
         $this->assertNotClosed();
 
-        return new PageNavigation($this, $url, $options['strict'] ?? false);
+        return new PageNavigation($this, $url, $options);
     }
 
     /**

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -66,17 +66,24 @@ class PageNavigation
      *
      * @param Page   $page
      * @param string $url
-     * @param bool   $strict by default this method will wait for the page to load even if a new navigation occurs
-     *                       (ie: a new loader replaced the initial navigation). Passing $string to true will make the navigation to fail
-     *                       if a new loader is generated
-     *
+     * @param array{
+     *     // by default this method will wait for the page to load even if a new navigation occurs
+     *     // (ie: a new loader replaced the initial navigation). Passing strict to true will make the navigation to fail
+     *     // if a new loader is generated
+     *     strict?: bool,
+     *     transitionType?: string,
+     *     frameId?: string,
+     *     referrer?: string,
+     *     referrerPolicy?: string,
+     *     // for more options checkout the documentation https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate
+     * } $options
      * @throws Exception\CommunicationException
      * @throws Exception\CommunicationException\CannotReadResponse
      * @throws Exception\CommunicationException\InvalidResponse
      *
      * @internal
      */
-    public function __construct(Page $page, string $url, bool $strict = false)
+    public function __construct(Page $page, string $url, array $options = [])
     {
         // make sure latest loaderId was pulled
         $page->getSession()->getConnection()->readData();
@@ -84,15 +91,18 @@ class PageNavigation
         // get previous loaderId for the navigation watcher
         $this->previousLoaderId = $page->getFrameManager()->getMainFrame()->getLatestLoaderId();
 
+        $params = array_merge(['url' => $url], $options);
+        unset($params['strict']);
+
         // send navigation message
         $this->navigateResponseReader = $page->getSession()->sendMessage(
-            new Message('Page.navigate', ['url' => $url])
+            new Message('Page.navigate', $params)
         );
 
         $this->page = $page;
         $this->frame = $page->getFrameManager()->getMainFrame();
         $this->url = $url;
-        $this->strict = $strict;
+        $this->strict = $options['strict'] ?? false;
     }
 
     /**

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -20,6 +20,7 @@ use HeadlessChromium\Exception\NavigationExpired;
 use HeadlessChromium\Frame;
 use HeadlessChromium\Page;
 use HeadlessChromium\Utils;
+use InvalidArgumentException;
 
 /**
  * A class that is aimed to be used withing the method Page::navigate.
@@ -66,17 +67,12 @@ class PageNavigation
      *
      * @param Page   $page
      * @param string $url
-     * @param array{
-     *     // by default this method will wait for the page to load even if a new navigation occurs
-     *     // (ie: a new loader replaced the initial navigation). Passing strict to true will make the navigation to fail
-     *     // if a new loader is generated
-     *     strict?: bool,
-     *     transitionType?: string,
-     *     frameId?: string,
-     *     referrer?: string,
-     *     referrerPolicy?: string,
-     *     // for more options checkout the documentation https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate
-     * } $options
+     * @param array  $options
+     *                        - strict: make waitForNavigation to fail if a new navigation is initiated. Default: false
+     *                        - referrer: the referrer URL to use for the navigation
+     *                        - referrerPolicy: the referrer policy to use for the navigation
+     *                        - transitionType: the transition type to use for the navigation
+     *
      * @throws Exception\CommunicationException
      * @throws Exception\CommunicationException\CannotReadResponse
      * @throws Exception\CommunicationException\InvalidResponse
@@ -85,14 +81,21 @@ class PageNavigation
      */
     public function __construct(Page $page, string $url, array $options = [])
     {
+        $params = ['url' => $url];
+
+        foreach ($options as $key => $value) {
+            if (\in_array($key, ['referrer', 'referrerPolicy', 'transitionType'], true)) {
+                $params[$key] = $value;
+            } elseif ('strict' !== $key) {
+                throw new InvalidArgumentException('Invalid option "'.$key.'" for page navigation. Supported options are "strict", "referrer", "referrerPolicy" and "transitionType".');
+            }
+        }
+
         // make sure latest loaderId was pulled
         $page->getSession()->getConnection()->readData();
 
         // get previous loaderId for the navigation watcher
         $this->previousLoaderId = $page->getFrameManager()->getMainFrame()->getLatestLoaderId();
-
-        $params = array_merge(['url' => $url], $options);
-        unset($params['strict']);
 
         // send navigation message
         $this->navigateResponseReader = $page->getSession()->sendMessage(

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -15,6 +15,7 @@ use finfo;
 use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Dom\Selector\XPathSelector;
 use HeadlessChromium\Exception\InvalidTimezoneId;
+use InvalidArgumentException;
 
 /**
  * @covers \HeadlessChromium\Page
@@ -61,6 +62,35 @@ class PageTest extends BaseTestCase
 
         self::assertSame('foobar', $value1);
         self::assertSame('barbaz', $value2);
+    }
+
+    public function testNavigateWithReferrer(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+
+        $page = $browser->createPage();
+
+        // the default referrer policy strips the referrer when navigating to a file:// URL
+        $page->navigate(self::sitePath('a.html'), ['referrer' => 'https://example.com/', 'referrerPolicy' => 'unsafeUrl'])->waitForNavigation();
+
+        $referrer = $page->evaluate('document.referrer')->getReturnValue();
+
+        self::assertSame('https://example.com/', $referrer);
+    }
+
+    public function testNavigateWithInvalidOption(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+
+        $page = $browser->createPage();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $page->navigate(self::sitePath('a.html'), ['frameId' => '1234']);
     }
 
     public function testSetTimezone(): void


### PR DESCRIPTION
There is currently no way to set the referrer for a navigation. Faking one with setExtraHTTPHeaders is not equivalent, since that stamps the header on every request including subresources, and a referrer policy cannot be expressed that way at all, which is what #530, #596 and #696 asked for. The only correct mechanism is the referrer, referrerPolicy and transitionType parameters of Page.navigate itself. This picks up @waahhhh's change from #701, retargeted at 1.16, with the original commit included as authored.

A follow-up commit replaces the blind passthrough of the options array with a validated allowlist of strict, referrer, referrerPolicy and transitionType, throwing an InvalidArgumentException for anything else, following the precedent of the screenshot options validation. Passing arbitrary protocol parameters through is not safe here: frameId in particular would break PageNavigation, which hard-codes the main frame for its loader tracking, and a typo in an option name should fail loudly rather than being silently dropped by the browser. The follow-up also restores the option documentation on the navigate docblocks rather than deferring to a protocol link, documents the options in the README, and adds tests covering the referrer end to end and the rejection of unsupported options. Since PageNavigation's constructor was internal until 1.16, reshaping its signature is safe here. Supersedes #701. Closes #696.