### PR TITLE
[1.16] Add AbstractBinaryInput::saveToStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allow choosing the box model in `Node::getPosition()`
 * Allow setting `referrer`, `referrerPolicy` and `transitionType` in `Page::navigate()`
 * Add `Page::authenticate` and `Page::clearAuthentication` methods
+* Add `AbstractBinaryInput::saveToStream` method
 
 
 ## 1.15.1 (UPCOMING)

--- a/README.md
+++ b/README.md
@@ -527,11 +527,11 @@ header('Expires: 0');
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Pragma: public');
 
-$outputStream = \fopen('php://output', 'w');
+$outputStream = fopen('php://output', 'w');
 
 $pdf->saveToStream($outputStream);
 
-\fclose($outputStream);
+fclose($outputStream);
 ```
 
 Options `headerTemplate` and `footerTemplate`:

--- a/README.md
+++ b/README.md
@@ -527,7 +527,11 @@ header('Expires: 0');
 header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 header('Pragma: public');
 
-echo base64_decode($pdf->getBase64());
+$outputStream = \fopen('php://output', 'w');
+
+$pdf->saveToStream($outputStream);
+
+\fclose($outputStream);
 ```
 
 Options `headerTemplate` and `footerTemplate`:

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -112,6 +112,46 @@ abstract class AbstractBinaryInput
     }
 
     /**
+     * Save data to the given stream.
+     *
+     * @param resource|null $stream If not provided, a php://temp is opened
+     * @param int           $timeout
+     *
+     * @throws FilesystemException
+     *
+     * @return resource
+     */
+    public function saveToStream($stream = null, int $timeout = 5000)
+    {
+        $response = $this->responseReader->waitForResponse($timeout);
+
+        if (!$response->isSuccessful()) {
+            throw $this->getException($response->getErrorMessage());
+        }
+
+        $ownStream = $stream === null;
+
+        if ($ownStream) {
+            $stream = \fopen('php://temp', 'r+');
+
+            if ($stream === false) {
+                throw new FilesystemException('Could not open a temporary stream.');
+            }
+        }
+
+        $filter = \stream_filter_append($stream, 'convert.base64-decode', STREAM_FILTER_WRITE);
+        \fwrite($stream, $response->getResultData('data'));
+        \stream_filter_remove($filter);
+        \fflush($stream);
+
+        if ($ownStream) {
+            \rewind($stream);
+        }
+
+        return $stream;
+    }
+
+    /**
      * @internal
      *
      * @return Exception

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -18,6 +18,9 @@ use HeadlessChromium\Exception\ScreenshotFailed;
 
 abstract class AbstractBinaryInput
 {
+    // must be a multiple of four so that each base64 chunk can be decoded on its own
+    private const WRITE_CHUNK_SIZE = 1024 * 1024;
+
     /**
      * @var ResponseReader
      */
@@ -114,10 +117,15 @@ abstract class AbstractBinaryInput
     /**
      * Save data to the given stream.
      *
-     * @param resource|null $stream If not provided, a php://temp is opened
+     * The data is decoded and written to the stream in chunks, avoiding
+     * allocating the decoded data in memory as a whole. The given stream
+     * must be blocking.
+     *
+     * @param resource|null $stream  If not provided, a php://temp stream is opened
      * @param int           $timeout
      *
      * @throws FilesystemException
+     * @throws ScreenshotFailed
      *
      * @return resource
      */
@@ -129,20 +137,45 @@ abstract class AbstractBinaryInput
             throw $this->getException($response->getErrorMessage());
         }
 
-        $ownStream = $stream === null;
+        $ownStream = null === $stream;
 
         if ($ownStream) {
             $stream = \fopen('php://temp', 'r+');
 
-            if ($stream === false) {
+            if (false === $stream) {
                 throw new FilesystemException('Could not open a temporary stream.');
+            }
+        } elseif (!\is_resource($stream)) {
+            throw new FilesystemException('The given stream is not a valid stream resource.');
+        }
+
+        $data = (string) $response->getResultData('data');
+        $length = \strlen($data);
+
+        for ($offset = 0; $offset < $length; $offset += self::WRITE_CHUNK_SIZE) {
+            $chunk = \base64_decode(\substr($data, $offset, self::WRITE_CHUNK_SIZE), true);
+
+            if (false === $chunk) {
+                throw $this->getException('Failed to decode the data to save.');
+            }
+
+            $chunkLength = \strlen($chunk);
+            $written = 0;
+
+            while ($written < $chunkLength) {
+                $result = @\fwrite($stream, 0 === $written ? $chunk : \substr($chunk, $written));
+
+                if (false === $result || 0 === $result) {
+                    throw new FilesystemException('Could not write to the given stream.');
+                }
+
+                $written += $result;
             }
         }
 
-        $filter = \stream_filter_append($stream, 'convert.base64-decode', STREAM_FILTER_WRITE);
-        \fwrite($stream, $response->getResultData('data'));
-        \stream_filter_remove($filter);
-        \fflush($stream);
+        if (!\fflush($stream)) {
+            throw new FilesystemException('Could not flush the given stream.');
+        }
 
         if ($ownStream) {
             \rewind($stream);

--- a/tests/PagePdfForTests.php
+++ b/tests/PagePdfForTests.php
@@ -18,4 +18,12 @@ class PagePdfForTests extends PagePdf
     public function __construct()
     {
     }
+
+    /**
+     * @param \HeadlessChromium\Communication\ResponseReader $responseReader
+     */
+    public function setResponseReader($responseReader): void
+    {
+        $this->responseReader = $responseReader;
+    }
 }

--- a/tests/PagePdfForTests.php
+++ b/tests/PagePdfForTests.php
@@ -11,6 +11,7 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Communication\ResponseReader;
 use HeadlessChromium\PageUtils\PagePdf;
 
 class PagePdfForTests extends PagePdf
@@ -19,10 +20,7 @@ class PagePdfForTests extends PagePdf
     {
     }
 
-    /**
-     * @param \HeadlessChromium\Communication\ResponseReader $responseReader
-     */
-    public function setResponseReader($responseReader): void
+    public function setResponseReader(ResponseReader $responseReader): void
     {
         $this->responseReader = $responseReader;
     }

--- a/tests/PagePdfTest.php
+++ b/tests/PagePdfTest.php
@@ -11,6 +11,8 @@
 
 namespace HeadlessChromium\Test;
 
+use HeadlessChromium\Communication\Response;
+use HeadlessChromium\Communication\ResponseReader;
 use HeadlessChromium\PageUtils\PagePdf;
 use InvalidArgumentException;
 use stdClass;
@@ -96,6 +98,33 @@ class PagePdfTest extends BaseTestCase
         self::assertInstanceOf(PagePdf::class, $this->pagePdf->setOptions([$optionName => $optionValue]));
     }
 
+    public function testSaveToStreamReturnsDecodedContent(): void
+    {
+        $content = 'Test';
+        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+
+        $stream = $pagePdf->saveToStream();
+
+        self::assertIsResource($stream);
+        self::assertSame($content, \stream_get_contents($stream));
+
+        \fclose($stream);
+    }
+
+    public function testSaveToStreamUsesProvidedStream(): void
+    {
+        $content = 'Test';
+        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+
+        $stream = \fopen('php://temp', 'r+');
+        $pagePdf->saveToStream($stream);
+
+        \rewind($stream);
+        self::assertSame($content, \stream_get_contents($stream));
+
+        \fclose($stream);
+    }
+
     private static function getOptionsDataset(string $optionName, array $optionValues): array
     {
         return \array_reduce(
@@ -107,5 +136,20 @@ class PagePdfTest extends BaseTestCase
             },
             []
         );
+    }
+
+    private function createPagePdfWithResponse(string $base64Data): PagePdfForTests
+    {
+        $response = $this->createMock(Response::class);
+        $response->method('isSuccessful')->willReturn(true);
+        $response->method('getResultData')->with('data')->willReturn($base64Data);
+
+        $responseReader = $this->createMock(ResponseReader::class);
+        $responseReader->method('waitForResponse')->willReturn($response);
+
+        $pagePdf = new PagePdfForTests();
+        $pagePdf->setResponseReader($responseReader);
+
+        return $pagePdf;
     }
 }

--- a/tests/PagePdfTest.php
+++ b/tests/PagePdfTest.php
@@ -11,8 +11,12 @@
 
 namespace HeadlessChromium\Test;
 
-use HeadlessChromium\Communication\Response;
+use HeadlessChromium\Communication\Connection;
+use HeadlessChromium\Communication\Message;
 use HeadlessChromium\Communication\ResponseReader;
+use HeadlessChromium\Communication\Socket\MockSocket;
+use HeadlessChromium\Exception\FilesystemException;
+use HeadlessChromium\Exception\PdfFailed;
 use HeadlessChromium\PageUtils\PagePdf;
 use InvalidArgumentException;
 use stdClass;
@@ -101,7 +105,7 @@ class PagePdfTest extends BaseTestCase
     public function testSaveToStreamReturnsDecodedContent(): void
     {
         $content = 'Test';
-        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+        $pagePdf = $this->createPagePdfWithResponse(\base64_encode($content));
 
         $stream = $pagePdf->saveToStream();
 
@@ -114,15 +118,75 @@ class PagePdfTest extends BaseTestCase
     public function testSaveToStreamUsesProvidedStream(): void
     {
         $content = 'Test';
-        $pagePdf  = $this->createPagePdfWithResponse(\base64_encode($content));
+        $pagePdf = $this->createPagePdfWithResponse(\base64_encode($content));
 
         $stream = \fopen('php://temp', 'r+');
         $pagePdf->saveToStream($stream);
 
+        // the decoding filter must have been removed: later writes go through verbatim
+        \fwrite($stream, 'raw');
+
         \rewind($stream);
+        self::assertSame($content.'raw', \stream_get_contents($stream));
+
+        \fclose($stream);
+    }
+
+    public function testSaveToStreamWritesLargeContentInChunks(): void
+    {
+        $content = \str_repeat('abcdef', 500000);
+        $pagePdf = $this->createPagePdfWithResponse(\base64_encode($content));
+
+        $stream = $pagePdf->saveToStream();
+
         self::assertSame($content, \stream_get_contents($stream));
 
         \fclose($stream);
+    }
+
+    public function testSaveToStreamRejectsNonWritableStream(): void
+    {
+        $pagePdf = $this->createPagePdfWithResponse(\base64_encode('Test'));
+
+        $this->expectException(FilesystemException::class);
+
+        $pagePdf->saveToStream(\fopen(__FILE__, 'r'));
+    }
+
+    public function testSaveToStreamRejectsClosedStream(): void
+    {
+        $pagePdf = $this->createPagePdfWithResponse(\base64_encode('Test'));
+
+        $stream = \fopen('php://temp', 'r+');
+        \fclose($stream);
+
+        $this->expectException(FilesystemException::class);
+
+        $pagePdf->saveToStream($stream);
+    }
+
+    public function testSaveToStreamRejectsMalformedData(): void
+    {
+        $pagePdf = $this->createPagePdfWithResponse('not base64!');
+
+        $this->expectException(PdfFailed::class);
+
+        $pagePdf->saveToStream();
+    }
+
+    public function testSaveToStreamRejectsZeroLengthWrites(): void
+    {
+        \stream_wrapper_register('zerowrite', ZeroWriteStreamForTests::class);
+
+        try {
+            $pagePdf = $this->createPagePdfWithResponse(\base64_encode('Test'));
+
+            $this->expectException(FilesystemException::class);
+
+            $pagePdf->saveToStream(\fopen('zerowrite://pdf', 'w'));
+        } finally {
+            \stream_wrapper_unregister('zerowrite');
+        }
     }
 
     private static function getOptionsDataset(string $optionName, array $optionValues): array
@@ -140,15 +204,14 @@ class PagePdfTest extends BaseTestCase
 
     private function createPagePdfWithResponse(string $base64Data): PagePdfForTests
     {
-        $response = $this->createMock(Response::class);
-        $response->method('isSuccessful')->willReturn(true);
-        $response->method('getResultData')->with('data')->willReturn($base64Data);
+        $message = new Message('Page.printToPDF', []);
+        $mockSocket = new MockSocket();
+        $connection = new Connection($mockSocket);
 
-        $responseReader = $this->createMock(ResponseReader::class);
-        $responseReader->method('waitForResponse')->willReturn($response);
+        $mockSocket->addReceivedData(\json_encode(['id' => $message->getId(), 'result' => ['data' => $base64Data]]));
 
         $pagePdf = new PagePdfForTests();
-        $pagePdf->setResponseReader($responseReader);
+        $pagePdf->setResponseReader(new ResponseReader($message, $connection));
 
         return $pagePdf;
     }

--- a/tests/ZeroWriteStreamForTests.php
+++ b/tests/ZeroWriteStreamForTests.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Chrome PHP.
+ *
+ * (c) Soufiane Ghzal <sghzal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HeadlessChromium\Test;
+
+/**
+ * A stream wrapper that accepts opens but writes nothing.
+ */
+class ZeroWriteStreamForTests
+{
+    /**
+     * @var resource|null
+     */
+    public $context;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
This supersedes #729 and resolves #495, retargeted to 1.16 since the PageUtils classes were promoted to the public API there. The first commit is @enricodias's change, squashed from #729, which adds saveToStream() for writing PDFs and screenshots directly to a stream such as php://output.

The follow-up commit reworks the write path so the method actually delivers the advertised memory behaviour: writing the whole base64 payload through the decoding filter in a single fwrite() allocates a full copy of the input internally, measuring the same peak memory as base64_decode(), while writing in one megabyte chunks measures only a couple of megabytes of overhead and remains byte exact across chunk boundaries.

The write is now also checked, since a non-writable stream previously attached the filter successfully, failed the write with only a warning, and returned as if the data had been saved, and a closed resource surfaced as a TypeError rather than the documented FilesystemException.

The filter is removed in a finally block so a failure cannot leave the caller's stream silently decoding their subsequent writes, and the docblock now declares the failure exception and no longer overstates the memory claim, since the base64 payload itself necessarily remains in memory in the response.