### PR TITLE
[1.16] Allow specifying options in `Page::screenshotElement()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Allow setting `referrer`, `referrerPolicy` and `transitionType` in `Page::navigate()`
 * Add `Page::authenticate` and `Page::clearAuthentication` methods
 * Add `AbstractBinaryInput::saveToStream` method
+* Allow specifying options in `Page::screenshotElement()`
 
 
 ## 1.15.1 (UPCOMING)

--- a/src/Page.php
+++ b/src/Page.php
@@ -863,11 +863,28 @@ class Page
         return new PageScreenshot($responseReader);
     }
 
-    public function screenshotElement(Node $node): PageScreenshot
+    /**
+     * Take a screenshot of the given element.
+     *
+     * The same options as for Page::screenshot are supported, except "clip",
+     * which is derived from the element and may not be given.
+     *
+     * @param Node  $node
+     * @param array $options see Page::screenshot
+     *
+     * @throws CommunicationException
+     *
+     * @return PageScreenshot
+     */
+    public function screenshotElement(Node $node, array $options = []): PageScreenshot
     {
-        return $this->screenshot([
-            'clip' => $node->getClip(),
-        ]);
+        if (\array_key_exists('clip', $options)) {
+            throw new InvalidArgumentException('Invalid options "clip" for element screenshot. The clip is derived from the element.');
+        }
+
+        $options['clip'] = $node->getClip();
+
+        return $this->screenshot($options);
     }
 
     /**

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -555,4 +555,38 @@ class PageTest extends BaseTestCase
         self::assertNotEmpty($screenshot->getBase64());
         self::assertGreaterThan(4000, \strlen($screenshot->getBase64()));
     }
+
+    public function testElementScreenshotWithOptions(): void
+    {
+        $finfo = new finfo(\FILEINFO_MIME_TYPE);
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate($this->sitePath('domForm.html'))->waitForNavigation();
+
+        $element = $page->dom()->querySelector('#myform');
+        $screenshot = $page->screenshotElement($element, ['format' => 'jpeg', 'quality' => 80]);
+
+        $mimeType = $finfo->buffer(\base64_decode($screenshot->getBase64()));
+
+        self::assertSame('image/jpeg', $mimeType);
+    }
+
+    public function testElementScreenshotWithClip(): void
+    {
+        $factory = new BrowserFactory();
+
+        $browser = $factory->createBrowser();
+        $page = $browser->createPage();
+
+        $page->navigate($this->sitePath('domForm.html'))->waitForNavigation();
+
+        $element = $page->dom()->querySelector('#myform');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $page->screenshotElement($element, ['clip' => $page->getFullPageClip()]);
+    }
 }


### PR DESCRIPTION
Page::screenshotElement() hard-codes its call to Page::screenshot() with only the element clip, so element screenshots are locked to the defaults and there is no way to choose the format, quality, optimizeForSpeed or captureBeyondViewport that full-page screenshots already support. This picks up @divinity76's change from #687, retargeted at 1.16: screenshotElement() now accepts the same options array as screenshot() and forwards it with the clip derived from the element. The question left open in the original diff about a caller-supplied clip is resolved by throwing an InvalidArgumentException, consistent with the other screenshot option validation, since silently discarding the caller's clip would be misleading and honouring it would defeat the purpose of the method. Tests cover the forwarded options producing a jpeg and the rejection of a clip, and a changelog entry is included. Supersedes #687.