### PR TITLE
[1.15] Complete the 1.15.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## 1.15.1 (UPCOMING)
 
-* Fixed mouse scrolling timing out when the page changes during the scroll
+* Fix mouse scrolling timing out when the page changes during the scroll
+* Fix Linux Chrome binary detection on POSIX shells
 
 
 ## 1.15.0 (2025-12-27)


### PR DESCRIPTION
The 1.15.1 changelog was missing an entry for #689, which fixed Linux Chrome binary detection on POSIX shells, a user-facing fix of the same kind as the `AutoDiscover` fixes listed in past releases. This adds the missing entry and also rewords the existing scroll fix entry from the past tense to the imperative mood used by every release section since 1.12.1.