### PR TITLE
[1.16] Allow fractional mouse coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Add `Page::authenticate` and `Page::clearAuthentication` methods
 * Add `AbstractBinaryInput::saveToStream` method
 * Allow specifying options in `Page::screenshotElement()`
+* Allow fractional mouse coordinates in `Mouse::move()`
+* Return floats from `Mouse::getPosition()`
 
 
 ## 1.15.1 (UPCOMING)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,30 +73,6 @@ parameters:
 			path: src/Communication/Session.php
 
 		-
-			message: '#^Parameter \#1 \$right of method HeadlessChromium\\Input\\Mouse\:\:scrollToBoundary\(\) expects int, \(float\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Input/Mouse.php
-
-		-
-			message: '#^Parameter \#1 \$x of method HeadlessChromium\\Input\\Mouse\:\:move\(\) expects int, float given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Input/Mouse.php
-
-		-
-			message: '#^Parameter \#2 \$bottom of method HeadlessChromium\\Input\\Mouse\:\:scrollToBoundary\(\) expects int, \(float\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Input/Mouse.php
-
-		-
-			message: '#^Parameter \#2 \$y of method HeadlessChromium\\Input\\Mouse\:\:move\(\) expects int, float given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Input/Mouse.php
-
-		-
 			message: '#^Parameter \#3 \$loaderId of method HeadlessChromium\\Page\:\:waitForReload\(\) expects null, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Dom/Node.php
+++ b/src/Dom/Node.php
@@ -208,7 +208,7 @@ class Node
         $this->scrollIntoView();
         $position = $this->getPosition();
         $this->page->mouse()
-            ->move((int) $position->getCenterX(), (int) $position->getCenterY())
+            ->move($position->getCenterX(), $position->getCenterY())
             ->click();
     }
 

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -42,8 +42,8 @@ class Mouse
      */
     protected $page;
 
-    protected $x = 0;
-    protected $y = 0;
+    protected $x = 0.0;
+    protected $y = 0.0;
 
     protected $button = self::BUTTON_NONE;
 
@@ -56,8 +56,8 @@ class Mouse
     }
 
     /**
-     * @param int        $x
-     * @param int        $y
+     * @param float      $x
+     * @param float      $y
      * @param array|null $options
      *
      * @throws CommunicationException
@@ -65,7 +65,7 @@ class Mouse
      *
      * @return $this
      */
-    public function move(int $x, int $y, ?array $options = null)
+    public function move(float $x, float $y, ?array $options = null)
     {
         $this->page->assertNotClosed();
 
@@ -336,7 +336,7 @@ class Mouse
         $rightBoundary = \floor($element['right']);
         $bottomBoundary = \floor($element['bottom']);
 
-        $this->scrollToBoundary($rightBoundary, $bottomBoundary);
+        $this->scrollToBoundary((int) $rightBoundary, (int) $bottomBoundary);
 
         $visibleArea = $this->page->getLayoutMetrics()->getLayoutViewport();
 
@@ -345,8 +345,8 @@ class Mouse
         $minX = $element['left'] - $offsetX;
         $minY = $element['top'] - $offsetY;
 
-        $positionX = \floor($minX + (($rightBoundary - $offsetX) - $minX) / 2);
-        $positionY = \ceil($minY + (($bottomBoundary - $offsetY) - $minY) / 2);
+        $positionX = $minX + (($rightBoundary - $offsetX) - $minX) / 2;
+        $positionY = $minY + (($bottomBoundary - $offsetY) - $minY) / 2;
 
         $this->move($positionX, $positionY);
 
@@ -450,7 +450,7 @@ class Mouse
     /**
      * Get the current mouse position.
      *
-     * @return array [x, y]
+     * @return array{x: float, y: float}
      */
     public function getPosition(): array
     {

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -86,7 +86,7 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         self::assertSame(100, $windowScrollY);
-        self::assertSame(100, $page->mouse()->getPosition()['y']);
+        self::assertSame(100.0, $page->mouse()->getPosition()['y']);
 
         // scrolling 100px up should revert the last action
         $page->mouse()->scrollUp(100);
@@ -94,7 +94,7 @@ class MouseApiTest extends BaseTestCase
         $windowScrollY = $page->evaluate('window.scrollY')->getReturnValue();
 
         self::assertSame(0, $windowScrollY);
-        self::assertSame(0, $page->mouse()->getPosition()['y']);
+        self::assertSame(0.0, $page->mouse()->getPosition()['y']);
 
         // try to scroll more than possible
         $page->mouse()->scrollDown(10000);
@@ -193,7 +193,7 @@ class MouseApiTest extends BaseTestCase
         $page->mouse()->scrollDown(100);
 
         self::assertSame(0, $page->evaluate('window.scrollY')->getReturnValue());
-        self::assertSame(['x' => 0, 'y' => 0], $page->mouse()->getPosition());
+        self::assertSame(['x' => 0.0, 'y' => 0.0], $page->mouse()->getPosition());
     }
 
     /**
@@ -210,7 +210,7 @@ class MouseApiTest extends BaseTestCase
         $page->mouse()->scrollDown(500); // Before patch this threw an OperationTimedOut Exception.
 
         self::assertSame(0, $page->evaluate('window.scrollY')->getReturnValue());
-        self::assertSame(['x' => 0, 'y' => 0], $page->mouse()->getPosition());
+        self::assertSame(['x' => 0.0, 'y' => 0.0], $page->mouse()->getPosition());
     }
 
     /**
@@ -382,5 +382,18 @@ class MouseApiTest extends BaseTestCase
 
         self::assertGreaterThanOrEqual(1, $y); // 87
         self::assertLessThanOrEqual(107, $y);
+    }
+
+    /**
+     * @throws CommunicationException
+     * @throws NoResponseAvailable
+     */
+    public function testMoveWithFractionalCoordinates(): void
+    {
+        $page = $this->openSitePage('b.html');
+
+        $page->mouse()->move(10.5, 20.25);
+
+        self::assertSame(['x' => 10.5, 'y' => 20.25], $page->mouse()->getPosition());
     }
 }

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -113,12 +113,12 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Chrome reports element and viewport coordinates as fractional CSS pixels and Input.dispatchMouseEvent accepts fractional values, but the mouse API forces whole pixels. Truncating a computed element centre can move a click by up to a pixel, which is enough to miss very small targets. Mouse::move() now accepts floats, and Node::click() and Mouse::findElement() no longer truncate the element centre before moving to it. As a consequence, Mouse::getPosition() now returns floats, which is recorded in the changelog. The scroll pipeline intentionally continues to work in whole pixels, since its settle logic compares truncated positions for equality.