### PR TITLE
Freeze trim characters ahead of PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 1.16.1 (Unreleased)
+
+* Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
+
 ## 1.16.0 (2026-07-06)
 
 * Promote the returned `PageUtils` helper classes to the public API

--- a/src/AutoDiscover.php
+++ b/src/AutoDiscover.php
@@ -42,7 +42,7 @@ class AutoDiscover
             case 'Windows':
                 return self::getFromRegistry() ?? '%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe';
             default:
-                return \rtrim(\explode("\n", (string) self::shellExec('command -v google-chrome || command -v chromium-browser || command -v chrome || command -v chromium'), 2)[0]) ?: 'chrome';
+                return \rtrim(\explode("\n", (string) self::shellExec('command -v google-chrome || command -v chromium-browser || command -v chrome || command -v chromium'), 2)[0], " \n\r\t\0\x0B") ?: 'chrome';
         }
     }
 

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -434,7 +434,7 @@ class BrowserProcess implements LoggerAwareInterface
 
                         // exception
                         $message = 'Chrome process stopped before startup completed.';
-                        $error = \trim($process->getErrorOutput());
+                        $error = \trim($process->getErrorOutput(), " \n\r\t\0\x0B");
                         if (!empty($error)) {
                             $message .= ' Additional info: '.$error;
                         }
@@ -442,7 +442,7 @@ class BrowserProcess implements LoggerAwareInterface
                         throw new RuntimeException($message);
                     }
 
-                    $output = \trim($process->getIncrementalErrorOutput());
+                    $output = \trim($process->getIncrementalErrorOutput(), " \n\r\t\0\x0B");
 
                     if ($output) {
                         // log
@@ -451,7 +451,7 @@ class BrowserProcess implements LoggerAwareInterface
                         $outputs = \explode(\PHP_EOL, $output);
 
                         foreach ($outputs as $output) {
-                            $output = \trim($output);
+                            $output = \trim($output, " \n\r\t\0\x0B");
 
                             // ignore empty line
                             if (empty($output)) {
@@ -470,7 +470,7 @@ class BrowserProcess implements LoggerAwareInterface
                                 throw new RuntimeException('Devtools could not start');
                             }
                             // log
-                            $this->logger->debug('process: ignoring output:'.\trim($output));
+                            $this->logger->debug('process: ignoring output:'.\trim($output, " \n\r\t\0\x0B"));
                         }
                     }
 

--- a/src/Input/KeyboardKeys.php
+++ b/src/Input/KeyboardKeys.php
@@ -218,6 +218,6 @@ trait KeyboardKeys
      */
     protected function setCurrentKey(string $key): void
     {
-        $this->currentKey = \ucfirst(\trim($key));
+        $this->currentKey = \ucfirst(\trim($key, " \n\r\t\0\x0B"));
     }
 }


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, `ltrim`, and `rtrim`, so calls relying on the default would change behavior there. This change passes the pre-8.6 set explicitly at the six call sites that relied on it, in the Linux binary auto-discovery, keyboard key normalization, and the browser process output handling, keeping behavior identical on every PHP version. An audit of the rest of the package found nothing else to fix: the remaining patterns already carry the PCRE `D` modifier or use no end anchor, and every `preg_match` failure path fails closed.
